### PR TITLE
[6]: Add default ISubscription implementation

### DIFF
--- a/src/Yaref92.Events/Abstractions/ISubscription.cs
+++ b/src/Yaref92.Events/Abstractions/ISubscription.cs
@@ -4,12 +4,9 @@ namespace Yaref92.Events.Abstractions;
 
 public interface ISubscription
 {
-    IDisposable ObservableSubscription { get; set; }
+    IDisposable ObservableSubscription { get; }
 
-    void AddSubscription(IDisposable subscription)
-    {
-        ObservableSubscription = subscription;
-    }
+    void AddSubscription(IDisposable subscription);
 
     void Dispose()
     {

--- a/src/Yaref92.Events/Subscription.cs
+++ b/src/Yaref92.Events/Subscription.cs
@@ -1,0 +1,15 @@
+﻿using System.Reactive.Disposables;
+
+using Yaref92.Events.Abstractions;
+
+namespace Yaref92.Events;
+
+public class Subscription : ISubscription
+{
+    public IDisposable ObservableSubscription { get; private set; } = Disposable.Empty;
+
+    public void AddSubscription(IDisposable subscription)
+    {
+        ObservableSubscription = subscription;
+    }
+}


### PR DESCRIPTION
In this commit, we add `Subscription`, a default implementation for `ISubscription` and we pushed the `AddSubscription` down there so that `ObservableSubscription` can be a get only in `ISubscription`

+semver: minor
