### PR TITLE
[10]feat: Ensure thread safety and add logging to EventAggregator

### DIFF
--- a/src/Yaref92.Events/Abstractions/IEventAggregator.cs
+++ b/src/Yaref92.Events/Abstractions/IEventAggregator.cs
@@ -4,7 +4,7 @@ public interface IEventAggregator
 {
     ISet<Type> EventTypes { get; }
 
-    void RegisterEventType<T>() where T : class, IDomainEvent;
+    bool RegisterEventType<T>() where T : class, IDomainEvent;
 
     void PublishEvent<T>(T domainEvent) where T : class, IDomainEvent;
 

--- a/src/Yaref92.Events/Yaref92.Events.csproj
+++ b/src/Yaref92.Events/Yaref92.Events.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />
     <PackageReference Include="System.Reactive" Version="6.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
This PR implements critical thread safety improvements and adds comprehensive logging capabilities to the EventAggregator, making it production-ready for concurrent environments.

## Changes

### 🔒 Thread Safety Improvements
- **Concurrent event type management** - Replaced `HashSet<Type>` with `ConcurrentDictionary<Type, byte>` for thread-safe event type registration
- **Synchronized Rx subject** - Wrapped the internal `Subject<IDomainEvent>` with `Subject.Synchronize()` to ensure thread-safe publishing and subscribing
- **Thread-safe operations** - All core operations (register, publish, subscribe) are now safe for concurrent access

### 📝 Logging & Diagnostics
- **Optional ILogger integration** - Added support for `ILogger<EventAggregator>` injection
- **Duplicate registration warnings** - Logs warnings when attempting to register already-registered event types
- **Null event detection** - Logs warnings and throws `ArgumentNullException` when attempting to publish null events
- **Added Microsoft.Extensions.Logging.Abstractions** package dependency

### 🛡️ API Safety Improvements
- **Enhanced RegisterEventType** - Now returns `bool` indicating whether the type was newly registered
- **Null event protection** - `PublishEvent<T>` now validates events are not null before publishing
- **Better error messages** - More descriptive exception messages for debugging

### 🧪 Comprehensive Testing
- **Concurrency tests** - Added tests to verify thread safety of registration and publish/subscribe operations
- **Logging validation** - Tests verify that appropriate warnings are logged for edge cases
- **API contract tests** - Updated tests to validate the new boolean return value from `RegisterEventType`

## Benefits
- **Production-ready** - Safe for use in multi-threaded applications
- **Better observability** - Comprehensive logging for debugging and monitoring
- **Improved reliability** - Prevents common runtime errors (null events, duplicate registrations)
- **Enhanced developer experience** - Clear feedback on operation success/failure

## Breaking Changes
- `RegisterEventType<T>()` now returns `bool` instead of `void`
- `PublishEvent<T>()` now throws `ArgumentNullException` for null events

## Migration Guide
Existing code calling `RegisterEventType<T>()` should be updated to handle the boolean return value:
```csharp
// Before
aggregator.RegisterEventType<MyEvent>();

// After
bool wasRegistered = aggregator.RegisterEventType<MyEvent>();
if (!wasRegistered)
{
    // Handle duplicate registration if needed
}
```

## Testing
All existing tests pass, and new concurrency tests verify thread safety under load.

+semver: patch