### PR TITLE
[18]fix: Remove explicit version tag

### DIFF
--- a/src/Yaref92.Events.Rx/Yaref92.Events.Rx.csproj
+++ b/src/Yaref92.Events.Rx/Yaref92.Events.Rx.csproj
@@ -1,1 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">  <ItemGroup>    <ProjectReference Include="..\Yaref92.Events\Yaref92.Events.csproj" />  </ItemGroup>  <PropertyGroup>    <TargetFramework>net8.0</TargetFramework>    <ImplicitUsings>enable</ImplicitUsings>    <Nullable>enable</Nullable>  </PropertyGroup></Project>
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\Yaref92.Events\Yaref92.Events.csproj" />
+  </ItemGroup>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/Yaref92.Events/Yaref92.Events.csproj
+++ b/src/Yaref92.Events/Yaref92.Events.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.2.0</Version>
     <Authors>yaref92</Authors>
     <Description>An event aggregator for my projects</Description>
     <PackageProjectUrl></PackageProjectUrl>


### PR DESCRIPTION
In this PR, we remove the explicit version number in a csproj file causing a wrong version number nupkg

+semver: none
