### PR TITLE
Add event deduplication mechanism to NetworkedEventAggregator

### DIFF
--- a/.github/workflows/manual-integration-tests.yml
+++ b/.github/workflows/manual-integration-tests.yml
@@ -1,0 +1,32 @@
+name: Manual Integration Tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build solution
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Run integration tests
+        run: dotnet test tests/Yaref92.Events.IntegrationTests --configuration Release --logger "trx;LogFileName=test_results.trx"
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-results
+          path: tests/Yaref92.Events.IntegrationTests/TestResults/ 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2024-06-29
+
+### Added
+
+- **Networked event aggregation**
+  - New `IEventTransport` abstraction for pluggable network transports
+  - `TCPEventTransport` implementation for peer-to-peer and client/server event propagation
+  - `NetworkedEventAggregator` for bridging local and networked event delivery
+  - Envelope-based JSON serialization with type safety
+- **Event deduplication and memory management**
+  - Deduplication of events using unique `EventId` on each event
+  - Configurable deduplication window (default: 15 minutes)
+  - Periodic cleanup of old event IDs to prevent memory bloat
+- **Event identity enforcement**
+  - All events must now inherit from `DomainEventBase`, which guarantees a unique `EventId` and UTC timestamp
+- **Documentation**
+  - Comprehensive README updates for networked usage, event requirements, deduplication, and security
+
+### Changed
+
+- Improved naming and clarity of deduplication methods
+- Removed redundant deduplication logic
+- Added proper resource disposal in tests to address analyzer warnings
+
+### Migration
+
+- All event types must now inherit from `DomainEventBase`
+- Existing in-memory usage is unaffected unless you opt-in to networked features
+- See the README for updated usage and migration notes
+
+---
+
 ## [1.1.0] - 2025-06-29
 
 ### Added

--- a/src/Yaref92.Events/Abstractions/IDomainEvent.cs
+++ b/src/Yaref92.Events/Abstractions/IDomainEvent.cs
@@ -1,10 +1,15 @@
 ﻿namespace Yaref92.Events.Abstractions;
 
 /// <summary>
-/// Represents a domain event with a UTC timestamp.
+/// Represents a domain event with a unique identifier and a UTC timestamp.
 /// </summary>
 public interface IDomainEvent
 {
+    /// <summary>
+    /// The unique identifier for this event instance.
+    /// </summary>
+    Guid EventId { get; }
+
     /// <summary>
     /// The UTC date and time when the event occurred.
     /// </summary>

--- a/src/Yaref92.Events/DomainEventBase.cs
+++ b/src/Yaref92.Events/DomainEventBase.cs
@@ -1,0 +1,25 @@
+﻿using Yaref92.Events.Abstractions;
+
+namespace Yaref92.Events;
+
+/// <summary>
+/// Provides a base implementation for domain events, ensuring a unique EventId and UTC timestamp.
+/// </summary>
+public abstract class DomainEventBase : IDomainEvent
+{
+    /// <inheritdoc/>
+    public Guid EventId { get; }
+    /// <inheritdoc/>
+    public DateTime DateTimeOccurredUtc { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DomainEventBase"/> class.
+    /// </summary>
+    /// <param name="dateTimeOccurredUtc">The UTC time the event occurred. Defaults to now if not provided.</param>
+    /// <param name="eventId">The unique event ID. If not provided or empty, a new Guid is generated.</param>
+    protected DomainEventBase(DateTime dateTimeOccurredUtc = default, Guid eventId = default)
+    {
+        EventId = eventId == default ? Guid.NewGuid() : eventId;
+        DateTimeOccurredUtc = dateTimeOccurredUtc == default ? DateTime.UtcNow : dateTimeOccurredUtc;
+    }
+}

--- a/src/Yaref92.Events/NetworkedEventAggregator.cs
+++ b/src/Yaref92.Events/NetworkedEventAggregator.cs
@@ -1,5 +1,6 @@
 ﻿using Yaref92.Events.Abstractions;
 using System.Collections.Concurrent;
+using Timer = System.Timers.Timer;
 
 namespace Yaref92.Events;
 
@@ -7,17 +8,24 @@ namespace Yaref92.Events;
 /// An event aggregator that bridges local in-memory event delivery with networked event propagation via an <see cref="IEventTransport"/>.
 /// Publishes events both locally and over the network, and dispatches received network events to local subscribers.
 /// </summary>
-public class NetworkedEventAggregator : IEventAggregator
+public class NetworkedEventAggregator : IEventAggregator, IDisposable
 {
     private readonly IEventAggregator _localAggregator;
     private readonly IEventTransport _transport;
     private readonly ConcurrentDictionary<Guid, DateTime> _recentEventIds = new();
-    private readonly TimeSpan _deduplicationWindow = TimeSpan.FromMinutes(15); // Placeholder for future config
+    private readonly TimeSpan _deduplicationWindow;
+    private readonly Timer _cleanupTimer;
+    private bool _disposed;
 
-    public NetworkedEventAggregator(IEventAggregator localAggregator, IEventTransport transport)
+    public NetworkedEventAggregator(IEventAggregator localAggregator, IEventTransport transport, TimeSpan? deduplicationWindow = null)
     {
         _localAggregator = localAggregator ?? throw new ArgumentNullException(nameof(localAggregator));
         _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+        _deduplicationWindow = deduplicationWindow ?? TimeSpan.FromMinutes(15);
+        _cleanupTimer = new Timer(_deduplicationWindow.TotalMilliseconds / 2);
+        _cleanupTimer.Elapsed += (s, e) => CleanupOldEventIds();
+        _cleanupTimer.AutoReset = true;
+        _cleanupTimer.Start();
     }
 
     public ISet<Type> EventTypes => _localAggregator.EventTypes;
@@ -29,9 +37,8 @@ public class NetworkedEventAggregator : IEventAggregator
         var registered = _localAggregator.RegisterEventType<T>();
         _transport.Subscribe<T>(async (evt, ct) =>
         {
-            if (!IsDuplicate(evt))
+            if (TryMarkSeen(evt))
             {
-                MarkSeen(evt);
                 await _localAggregator.PublishEventAsync(evt, ct).ConfigureAwait(false);
             }
         });
@@ -75,15 +82,29 @@ public class NetworkedEventAggregator : IEventAggregator
         _localAggregator.UnsubscribeFromEventType(subscriber);
     }
 
-    // Basic deduplication using EventId
-    private bool IsDuplicate(IDomainEvent evt)
+    // Deduplication: returns true if this is the first time the event is seen (not a duplicate)
+    private bool TryMarkSeen(IDomainEvent evt)
     {
-        return !_recentEventIds.TryAdd(evt.EventId, DateTime.UtcNow);
+        return _recentEventIds.TryAdd(evt.EventId, DateTime.UtcNow);
     }
 
-    private void MarkSeen(IDomainEvent evt)
+    private void CleanupOldEventIds()
     {
-        _recentEventIds[evt.EventId] = DateTime.UtcNow;
-        // TODO: Cleanup old keys periodically
+        DateTime threshold = DateTime.UtcNow - _deduplicationWindow;
+        foreach (var kvp in _recentEventIds)
+        {
+            if (kvp.Value < threshold)
+            {
+                _recentEventIds.TryRemove(kvp.Key, out _);
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _cleanupTimer?.Stop();
+        _cleanupTimer?.Dispose();
+        _disposed = true;
     }
 } 

--- a/tests/Yaref92.Events.IntegrationTests/DummyEvent.cs
+++ b/tests/Yaref92.Events.IntegrationTests/DummyEvent.cs
@@ -1,19 +1,14 @@
-﻿using Yaref92.Events.Abstractions;
-
-namespace Yaref92.Events.IntegrationTests;
+﻿namespace Yaref92.Events.IntegrationTests;
 
 /// <summary>
 /// This event is only a dummy to be used in tests
 /// </summary>
-public class DummyEvent : IDomainEvent
+public class DummyEvent : DomainEventBase
 {
-    public DateTime DateTimeOccurredUtc { get; }
-
     public string? Text { get; }
 
-    public DummyEvent(DateTime? dateTimeOccurredUtc = null, string? text = null)
+    public DummyEvent(DateTime dateTimeOccurredUtc = default, string? text = null) : base(dateTimeOccurredUtc)
     {
-        DateTimeOccurredUtc = dateTimeOccurredUtc ?? DateTime.UtcNow;
         Text = text;
     }
 }

--- a/tests/Yaref92.Events.Rx.UnitTests/DummyEvent.cs
+++ b/tests/Yaref92.Events.Rx.UnitTests/DummyEvent.cs
@@ -1,11 +1,11 @@
-﻿using Yaref92.Events.Abstractions;
-
-namespace Yaref92.Events.Rx.UnitTests;
+﻿namespace Yaref92.Events.Rx.UnitTests;
 
 /// <summary>
 /// This event is only a dummy to be used in tests
 /// </summary>
-public class DummyEvent : IDomainEvent
+public class DummyEvent : DomainEventBase
 {
-    public DateTime DateTimeOccurredUtc => throw new NotImplementedException();
+    public DummyEvent() : base()
+    {
+    }
 }

--- a/tests/Yaref92.Events.Rx.UnitTests/RxEventAggregatorTests.cs
+++ b/tests/Yaref92.Events.Rx.UnitTests/RxEventAggregatorTests.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Threading.Tasks;
+﻿using System.Reactive.Linq;
+
 using FluentAssertions;
-using NUnit.Framework;
+
 using NSubstitute;
+
 using Yaref92.Events.Abstractions;
-using Yaref92.Events.Rx;
 using Yaref92.Events.Rx.Abstractions;
 
 namespace Yaref92.Events.Rx.UnitTests;
@@ -49,7 +47,7 @@ public class RxEventAggregatorTests
 
     public class RxDummySubscriber : IRxSubscriber<DummyEvent>
     {
-        public DummyEvent ReceivedEvent { get; private set; }
+        public DummyEvent ReceivedEvent { get; private set; } = new DummyEvent();
         public int OnNextCount { get; private set; }
         public void OnNext(DummyEvent value)
         {
@@ -147,7 +145,7 @@ public class RxEventAggregatorTests
 
     public class OtherRxDummySubscriber : IRxSubscriber<OtherDummyEvent>
     {
-        public OtherDummyEvent ReceivedEvent { get; private set; }
+        public OtherDummyEvent ReceivedEvent { get; private set; } = new OtherDummyEvent();
         public int OnNextCount { get; private set; }
         public void OnNext(OtherDummyEvent value)
         {
@@ -159,7 +157,6 @@ public class RxEventAggregatorTests
     }
 }
 
-public class OtherDummyEvent : IDomainEvent
+public class OtherDummyEvent : DomainEventBase
 {
-    public DateTime DateTimeOccurredUtc => DateTime.UtcNow;
 } 

--- a/tests/Yaref92.Events.UnitTests/DummyEvent.cs
+++ b/tests/Yaref92.Events.UnitTests/DummyEvent.cs
@@ -1,19 +1,15 @@
-﻿using Yaref92.Events.Abstractions;
-
-namespace Yaref92.Events.UnitTests;
+﻿namespace Yaref92.Events.UnitTests;
 
 /// <summary>
 /// This event is only a dummy to be used in tests
 /// </summary>
-public class DummyEvent : IDomainEvent
+public class DummyEvent : DomainEventBase
 {
-    public DateTime DateTimeOccurredUtc { get; }
-
     public string? Text { get; }
 
-    public DummyEvent(DateTime dateTimeOccurredUtc = default, string? text = null)
+    public DummyEvent(string? text = null, DateTime dateTimeOccurredUtc = default, Guid eventId = default)
+        : base(dateTimeOccurredUtc, eventId)
     {
-        DateTimeOccurredUtc = dateTimeOccurredUtc;
         Text = text;
     }
 }

--- a/tests/Yaref92.Events.UnitTests/EventAggregatorTests.cs
+++ b/tests/Yaref92.Events.UnitTests/EventAggregatorTests.cs
@@ -610,14 +610,13 @@ internal class EventAggregatorTests
     {
         _aggregator.RegisterEventType<DummyEvent>();
         var id = Guid.NewGuid();
-        var evt = new DummyEvent(DateTime.UtcNow, id, "test");
+        var evt = new DummyEvent("test", eventId: id);
         _aggregator.SubscribeToEventType(_subscriber);
         _aggregator.PublishEvent(evt);
         evt.EventId.Should().Be(id);
     }
 }
 
-public class OtherDummyEvent : IDomainEvent
+public class OtherDummyEvent : DomainEventBase
 {
-    public DateTime DateTimeOccurredUtc => DateTime.UtcNow;
 }

--- a/tests/Yaref92.Events.UnitTests/EventAggregatorTests.cs
+++ b/tests/Yaref92.Events.UnitTests/EventAggregatorTests.cs
@@ -604,6 +604,17 @@ internal class EventAggregatorTests
     {
         public Task OnNextAsync(DummyEvent value, CancellationToken cancellationToken = default) => throw new InvalidOperationException("fail");
     }
+
+    [Test]
+    public void PublishEvent_Preserves_Existing_EventId()
+    {
+        _aggregator.RegisterEventType<DummyEvent>();
+        var id = Guid.NewGuid();
+        var evt = new DummyEvent(DateTime.UtcNow, id, "test");
+        _aggregator.SubscribeToEventType(_subscriber);
+        _aggregator.PublishEvent(evt);
+        evt.EventId.Should().Be(id);
+    }
 }
 
 public class OtherDummyEvent : IDomainEvent

--- a/tests/Yaref92.Events.UnitTests/NetworkedEventAggregatorTests.cs
+++ b/tests/Yaref92.Events.UnitTests/NetworkedEventAggregatorTests.cs
@@ -130,4 +130,10 @@ internal class NetworkedEventAggregatorTests
         // Assert
         await _localAggregator.Received(1).PublishEventAsync(evt, Arg.Any<CancellationToken>());
     }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _networkedAggregator?.Dispose();
+    }
 } 

--- a/tests/Yaref92.Events.UnitTests/Serialization/JsonEventSerializerTests.cs
+++ b/tests/Yaref92.Events.UnitTests/Serialization/JsonEventSerializerTests.cs
@@ -14,7 +14,7 @@ public class JsonEventSerializerTests
     {
         // Arrange
         var serializer = new JsonEventSerializer();
-        var evt = new DummyEvent(DateTime.UtcNow, "test");
+        var evt = new DummyEvent("test");
 
         // Act
         var json = serializer.Serialize(evt);
@@ -41,5 +41,24 @@ public class JsonEventSerializerTests
         var serializer = new JsonEventSerializer();
         Action act = () => serializer.Deserialize("not a json");
         act.Should().Throw<JsonException>();
+    }
+
+    [Test]
+    public void Serialize_And_Deserialize_Preserves_EventId()
+    {
+        var serializer = new JsonEventSerializer();
+        DummyEvent evt = new("test");
+        var json = serializer.Serialize(evt);
+        (Type? type, Abstractions.IDomainEvent? domainEvent) = serializer.Deserialize(json);
+        type.Should().Be(typeof(DummyEvent));
+        domainEvent.Should().NotBeNull();
+        domainEvent!.EventId.Should().Be(evt.EventId);
+    }
+
+    [Test]
+    public void New_DummyEvent_Has_NonEmpty_EventId()
+    {
+        var evt = new DummyEvent();
+        evt.EventId.Should().NotBe(Guid.Empty);
     }
 } 


### PR DESCRIPTION
### Motivation

To ensure robust, idempotent, and safe event propagation in distributed and networked scenarios, we need to prevent duplicate event processing. This PR introduces a deduplication mechanism to the `NetworkedEventAggregator` to address this.

---

### Summary of Changes

- **Deduplication Logic**
  - Uses a `ConcurrentDictionary<Guid, DateTime>` to track recently seen event IDs.
  - Deduplication window is configurable via the constructor (default: 15 minutes).
  - Periodic cleanup of old event IDs is implemented using a timer to prevent memory bloat.
  - The deduplication check is atomic: `TryMarkSeen` both checks and marks an event as seen.

- **Event Identity**
  - All event types now inherit from `DomainEventBase`, which guarantees a unique `EventId` and UTC timestamp for every event instance.

- **Code Quality**
  - Removed redundant `MarkSeen` logic.
  - Improved naming and clarity of deduplication methods.
  - Added proper resource disposal in tests to address analyzer warnings.

- **Testing & Compliance**
  - All unit and integration tests pass.
  - The codebase is compliant with deduplication, event identity, and serialization requirements.

---

### Notes

- The deduplication window can be adjusted as needed for different deployment scenarios.
- The deduplication mechanism is isolated to the networked aggregator and does not affect local/in-memory event delivery.
- All event types in the codebase are now guaranteed to have a unique `EventId` at creation.

+semver: minor