### PR TITLE
Improve TCP transport background task handling

### DIFF
--- a/src/Yaref92.Events/Transports/TCPEventTransport.cs
+++ b/src/Yaref92.Events/Transports/TCPEventTransport.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Concurrent;
+using System.IO;
 using System.Net;
 using System.Net.Sockets;
-using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Yaref92.Events.Abstractions;
 using Yaref92.Events.Serialization;
@@ -18,7 +20,9 @@ public class TCPEventTransport : IEventTransport, IDisposable
     private readonly ConcurrentDictionary<Type, ConcurrentBag<Func<object, CancellationToken, Task>>> _handlers = new();
     private readonly int _listenPort;
     private TcpListener? _listener;
-    private readonly ConcurrentBag<TcpClient> _clients = new();
+    private readonly ConcurrentDictionary<TcpClient, byte> _clients = new();
+    private readonly ConcurrentDictionary<TcpClient, Task> _receiveTasks = new();
+    private Task? _acceptConnectionsTask;
     private CancellationTokenSource? _cts;
     private readonly IEventSerializer _serializer;
 
@@ -31,12 +35,34 @@ public class TCPEventTransport : IEventTransport, IDisposable
     /// <summary>
     /// Starts listening for incoming TCP connections.
     /// </summary>
-    public async Task StartListeningAsync(CancellationToken cancellationToken = default)
+    public Task StartListeningAsync(CancellationToken cancellationToken = default)
     {
+        if (_listener is not null)
+        {
+            throw new InvalidOperationException("The transport is already listening.");
+        }
+
         _listener = new TcpListener(IPAddress.Any, _listenPort);
         _listener.Start();
-        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        _ = AcceptConnectionsLoopAsync(_cts.Token);
+
+        _cts ??= new CancellationTokenSource();
+
+        var registration = default(CancellationTokenRegistration);
+        var registrationSet = false;
+        if (cancellationToken.CanBeCanceled)
+        {
+            registration = cancellationToken.Register(() => _cts.Cancel());
+            registrationSet = true;
+        }
+
+        _acceptConnectionsTask = AcceptConnectionsLoopAsync(_cts.Token);
+        TrackBackgroundTask(_acceptConnectionsTask, nameof(AcceptConnectionsLoopAsync));
+
+        if (registrationSet)
+        {
+            _acceptConnectionsTask!.ContinueWith(_ => registration.Dispose(), TaskContinuationOptions.ExecuteSynchronously);
+        }
+        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -65,8 +91,15 @@ public class TCPEventTransport : IEventTransport, IDisposable
             client.Dispose();
             throw new InvalidOperationException($"Failed to connect to {host}:{port}: the TCP client is not connected.");
         }
-        _clients.Add(client);
-        _ = ReceiveMessagesLoopAsync(client, cancellationToken);
+        _cts ??= new CancellationTokenSource();
+
+        if (!_clients.TryAdd(client, 0))
+        {
+            client.Dispose();
+            throw new InvalidOperationException("The TCP client is already tracked by the transport.");
+        }
+
+        StartReceiveLoopForClient(client, cancellationToken);
     }
 
     public async Task PublishAsync<T>(T domainEvent, CancellationToken cancellationToken = default) where T : class, IDomainEvent
@@ -75,7 +108,7 @@ public class TCPEventTransport : IEventTransport, IDisposable
         var bytes = System.Text.Encoding.UTF8.GetBytes(payload);
         var lengthPrefix = BitConverter.GetBytes(bytes.Length);
 
-        foreach (var client in _clients)
+        foreach (var client in _clients.Keys)
         {
             try
             {
@@ -86,6 +119,7 @@ public class TCPEventTransport : IEventTransport, IDisposable
             catch
             {
                 // TODO: Handle broken connections
+                CleanupClient(client);
             }
         }
     }
@@ -98,52 +132,250 @@ public class TCPEventTransport : IEventTransport, IDisposable
 
     private async Task AcceptConnectionsLoopAsync(CancellationToken cancellationToken)
     {
-        while (!cancellationToken.IsCancellationRequested)
+        try
         {
-            var client = await _listener!.AcceptTcpClientAsync(cancellationToken);
-            _clients.Add(client);
-            _ = ReceiveMessagesLoopAsync(client, cancellationToken);
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                TcpClient? client = null;
+                try
+                {
+                    if (_listener is null)
+                    {
+                        throw new InvalidOperationException("TCP listener is not initialized.");
+                    }
+
+                    client = await _listener.AcceptTcpClientAsync(cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (SocketException ex)
+                {
+                    Console.Error.WriteLine($"{nameof(AcceptConnectionsLoopAsync)} socket error: {ex}");
+                    continue;
+                }
+                catch (IOException ex)
+                {
+                    Console.Error.WriteLine($"{nameof(AcceptConnectionsLoopAsync)} I/O error: {ex}");
+                    continue;
+                }
+                catch (ObjectDisposedException)
+                {
+                    break;
+                }
+
+                if (client is null)
+                {
+                    continue;
+                }
+
+                if (!_clients.TryAdd(client, 0))
+                {
+                    client.Dispose();
+                    continue;
+                }
+
+                StartReceiveLoopForClient(client, cancellationToken);
+            }
+        }
+        finally
+        {
+            // no-op, method exits when cancellation requested or listener disposed
         }
     }
 
     private async Task ReceiveMessagesLoopAsync(TcpClient client, CancellationToken cancellationToken)
     {
-        var stream = client.GetStream();
-        var buffer = new byte[4];
-        while (!cancellationToken.IsCancellationRequested)
+        try
         {
-            // Read length prefix
-            int readLength = await stream.ReadAsync(buffer.AsMemory(0, 4), cancellationToken);
-            if (readLength < 4) break;
-            int length = BitConverter.ToInt32(buffer, 0);
-            var data = new byte[length];
-            int received = 0;
-            while (received < length)
+            var stream = client.GetStream();
+            var buffer = new byte[4];
+            while (!cancellationToken.IsCancellationRequested)
             {
-                readLength = await stream.ReadAsync(data.AsMemory(received, length - received), cancellationToken);
-                if (readLength == 0) break;
-                received += readLength;
-            }
-            if (received < length) break;
-            var payload = System.Text.Encoding.UTF8.GetString(data);
-            (Type? type, IDomainEvent? domainEvent) = _serializer.Deserialize(payload);
-            if (type != null && _handlers.TryGetValue(type, out var handlersForType))
-            {
-                foreach (var handler in handlersForType)
+                int readLength;
+                try
                 {
-                    await handler(domainEvent!, cancellationToken);
+                    readLength = await stream.ReadAsync(buffer.AsMemory(0, 4), cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (IOException ex)
+                {
+                    Console.Error.WriteLine($"{nameof(ReceiveMessagesLoopAsync)} I/O error while reading length prefix: {ex}");
+                    break;
+                }
+                catch (SocketException ex)
+                {
+                    Console.Error.WriteLine($"{nameof(ReceiveMessagesLoopAsync)} socket error while reading length prefix: {ex}");
+                    break;
+                }
+
+                if (readLength < 4)
+                {
+                    break;
+                }
+
+                int length = BitConverter.ToInt32(buffer, 0);
+                var data = new byte[length];
+                int received = 0;
+                while (received < length && !cancellationToken.IsCancellationRequested)
+                {
+                    try
+                    {
+                        readLength = await stream.ReadAsync(data.AsMemory(received, length - received), cancellationToken);
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        break;
+                    }
+                    catch (IOException ex)
+                    {
+                        Console.Error.WriteLine($"{nameof(ReceiveMessagesLoopAsync)} I/O error while reading payload: {ex}");
+                        received = 0;
+                        break;
+                    }
+                    catch (SocketException ex)
+                    {
+                        Console.Error.WriteLine($"{nameof(ReceiveMessagesLoopAsync)} socket error while reading payload: {ex}");
+                        received = 0;
+                        break;
+                    }
+
+                    if (readLength == 0)
+                    {
+                        received = 0;
+                        break;
+                    }
+
+                    received += readLength;
+                }
+
+                if (received < length)
+                {
+                    break;
+                }
+
+                var payload = System.Text.Encoding.UTF8.GetString(data);
+                (Type? type, IDomainEvent? domainEvent) = _serializer.Deserialize(payload);
+                if (type != null && _handlers.TryGetValue(type, out var handlersForType))
+                {
+                    foreach (var handler in handlersForType)
+                    {
+                        await handler(domainEvent!, cancellationToken);
+                    }
                 }
             }
+        }
+        catch (IOException ex)
+        {
+            Console.Error.WriteLine($"{nameof(ReceiveMessagesLoopAsync)} encountered an I/O error: {ex}");
+        }
+        catch (SocketException ex)
+        {
+            Console.Error.WriteLine($"{nameof(ReceiveMessagesLoopAsync)} encountered a socket error: {ex}");
+        }
+        finally
+        {
+            CleanupClient(client);
         }
     }
 
     public void Dispose()
     {
         _cts?.Cancel();
+
+        try
+        {
+            _acceptConnectionsTask?.Wait();
+        }
+        catch (AggregateException ex)
+        {
+            Console.Error.WriteLine($"{nameof(AcceptConnectionsLoopAsync)} faulted during disposal: {ex.Flatten()}");
+        }
+
+        foreach (var task in _receiveTasks.Values)
+        {
+            try
+            {
+                task.Wait();
+            }
+            catch (AggregateException ex)
+            {
+                Console.Error.WriteLine($"{nameof(ReceiveMessagesLoopAsync)} faulted during disposal: {ex.Flatten()}");
+            }
+        }
+        _receiveTasks.Clear();
+
         _listener?.Stop();
-        foreach (var client in _clients)
+        foreach (var client in _clients.Keys)
         {
             client.Dispose();
         }
+        _clients.Clear();
+        _cts?.Dispose();
+        _cts = null;
+        _listener = null;
+        _acceptConnectionsTask = null;
     }
-} 
+
+    private void StartReceiveLoopForClient(TcpClient client, CancellationToken cancellationToken)
+    {
+        if (_cts is null)
+        {
+            _cts = new CancellationTokenSource();
+        }
+
+        CancellationTokenSource? linkedCts = null;
+        CancellationToken token;
+        if (cancellationToken.CanBeCanceled && cancellationToken != _cts.Token)
+        {
+            linkedCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token, cancellationToken);
+            token = linkedCts.Token;
+        }
+        else
+        {
+            token = _cts.Token;
+        }
+
+        var receiveTask = ReceiveMessagesLoopAsync(client, token);
+        _receiveTasks[client] = receiveTask;
+        receiveTask.ContinueWith(t =>
+        {
+            _receiveTasks.TryRemove(client, out _);
+            linkedCts?.Dispose();
+            if (t.IsFaulted && t.Exception is not null)
+            {
+                Console.Error.WriteLine($"{nameof(ReceiveMessagesLoopAsync)} task faulted: {t.Exception.Flatten()}");
+            }
+        }, TaskContinuationOptions.ExecuteSynchronously);
+    }
+
+    private void TrackBackgroundTask(Task task, string taskName)
+    {
+        task.ContinueWith(t =>
+        {
+            if (t.IsFaulted && t.Exception is not null)
+            {
+                Console.Error.WriteLine($"{taskName} task faulted: {t.Exception.Flatten()}");
+            }
+        }, TaskContinuationOptions.ExecuteSynchronously);
+    }
+
+    private void CleanupClient(TcpClient client)
+    {
+        if (_clients.TryRemove(client, out _))
+        {
+            try
+            {
+                client.Close();
+            }
+            finally
+            {
+                client.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- track the accept and receive loops so failures are logged instead of fire-and-forget
- harden TCP accept and receive loops to catch socket/I-O faults and clean up disconnected clients
- cancel and wait on background tasks during disposal to avoid unobserved exceptions

## Testing
- dotnet test *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ff56eda6288326897b22da5106ff0e