### PR TITLE
Document retaining TCP transport reference for peer connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ networkedAggregator.PublishEvent(new MyEvent("Hello, world!"));
 await transport.ConnectToPeerAsync("remotehost", 9000);
 ```
 
+> **Note:** If you plan to call `transport.ConnectToPeerAsync` later, keep a reference to the original `TCPEventTransport` instance. `NetworkedEventAggregator` only depends on the `IEventTransport` abstraction, so it cannot initiate new peer connections once the transport reference goes out of scope.
+
 ### Event Type Requirements
 
 All events must inherit from `DomainEventBase`:


### PR DESCRIPTION
## Summary
- clarify that callers should keep their `TCPEventTransport` instance when planning to connect to peers later
- explain that `NetworkedEventAggregator` relies only on the `IEventTransport` abstraction and cannot re-initiate connections

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69020ad25058832690ef341044f01969