### PR TITLE
Prepare 1.2.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2025-10-23
+
+### Fixed
+
+- Hardened the TCP transport to surface publish failures and ensure background tasks recover cleanly.
+- Ensured TCP client connections are cleaned up after failures and documented how to retain transport references for peer scenarios.
+- Expanded test coverage for TCP publish failure paths, including socket error handling through the event aggregator.
+
+---
+
 ## [1.2.0] - 2024-06-29
 
 ### Added


### PR DESCRIPTION
## Summary
- document the 1.2.1 bugfix release in the changelog, focusing on TCP transport stability updates

## Testing
- not run

+semver:patch