### PR TITLE
Add resilience integration and unit tests

### DIFF
--- a/tests/Yaref92.Events.IntegrationTests/ResilientSessionIntegrationTests.cs
+++ b/tests/Yaref92.Events.IntegrationTests/ResilientSessionIntegrationTests.cs
@@ -1,0 +1,475 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using NUnit.Framework;
+
+using Yaref92.Events.Transports;
+
+namespace Yaref92.Events.IntegrationTests;
+
+[TestFixture]
+[Explicit("Integration tests require local TCP sockets and timing-sensitive coordination.")]
+[Category("Integration")]
+public class ResilientSessionIntegrationTests
+{
+    [Test]
+    public async Task PersistentClient_Reconnects_And_Replays_Outbox_On_Drop()
+    {
+        // Arrange
+        var options = new ResilientSessionOptions
+        {
+            HeartbeatInterval = TimeSpan.FromMilliseconds(25),
+            HeartbeatTimeout = TimeSpan.FromMilliseconds(80),
+            BackoffInitialDelay = TimeSpan.FromMilliseconds(20),
+            BackoffMaxDelay = TimeSpan.FromMilliseconds(50),
+        };
+
+        var port = GetFreeTcpPort();
+        await using var server = new ResilientTcpServer(port, options);
+        var deliveries = new List<string>();
+        var firstDeliveryTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var replayDeliveryTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        server.MessageReceived += async (_, payload, _) =>
+        {
+            deliveries.Add(payload);
+            if (deliveries.Count == 1)
+            {
+                firstDeliveryTcs.TrySetResult();
+            }
+            else if (deliveries.Count == 2)
+            {
+                replayDeliveryTcs.TrySetResult();
+            }
+
+            await Task.CompletedTask;
+        };
+
+        await server.StartAsync().ConfigureAwait(false);
+
+        await using var clientHost = new TestPersistentClientHost("127.0.0.1", port, options);
+        clientHost.DropNextAck();
+        await clientHost.StartAsync(CancellationToken.None).ConfigureAwait(false);
+
+        var payload = $"payload-{Guid.NewGuid():N}";
+        var messageId = await clientHost.Client.EnqueueEventAsync(payload, CancellationToken.None).ConfigureAwait(false);
+
+        await firstDeliveryTcs.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        await clientHost.WaitForConnectionCountAsync(2, TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        await replayDeliveryTcs.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        await clientHost.WaitForAckCountAsync(1, TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        await clientHost.WaitForOutboxCountAsync(0, TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+
+        deliveries.Should().HaveCount(2).And.OnlyContain(d => d == payload);
+        clientHost.ConnectionCount.Should().BeGreaterThanOrEqualTo(2);
+        clientHost.AcknowledgedMessageIds.Should().ContainSingle(id => id == messageId);
+    }
+
+    [Test]
+    public async Task Broadcasts_Are_Redelivered_Until_Acknowledged_By_All_Peers()
+    {
+        // Arrange
+        var options = new ResilientSessionOptions
+        {
+            HeartbeatInterval = TimeSpan.FromMilliseconds(25),
+            HeartbeatTimeout = TimeSpan.FromMilliseconds(80),
+            BackoffInitialDelay = TimeSpan.FromMilliseconds(10),
+            BackoffMaxDelay = TimeSpan.FromMilliseconds(40),
+        };
+
+        var port = GetFreeTcpPort();
+        await using var server = new ResilientTcpServer(port, options);
+        await server.StartAsync().ConfigureAwait(false);
+
+        await using var peerA = new TestPersistentClientHost("127.0.0.1", port, options);
+        await using var peerB = new TestPersistentClientHost("127.0.0.1", port, options);
+        peerB.DropNextMessage();
+
+        await peerA.StartAsync(CancellationToken.None).ConfigureAwait(false);
+        await peerB.StartAsync(CancellationToken.None).ConfigureAwait(false);
+
+        var payload = $"broadcast-{Guid.NewGuid():N}";
+        server.QueueBroadcast(payload);
+
+        await peerA.WaitForMessageCountAsync(1, TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        await peerB.WaitForMessageCountAsync(2, TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        await peerA.WaitForAckCountAsync(1, TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        await peerB.WaitForAckCountAsync(1, TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        await WaitForServerInflightToDrainAsync(server, TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+
+        peerA.ReceivedPayloads.Should().ContainSingle(p => p == payload);
+        peerB.ReceivedPayloads.Should().HaveCount(2);
+        peerB.ConnectionCount.Should().BeGreaterThanOrEqualTo(2);
+    }
+
+    private static async Task WaitForServerInflightToDrainAsync(ResilientTcpServer server, TimeSpan timeout)
+    {
+        var sessionsField = typeof(ResilientTcpServer).GetField("_sessions", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < timeout)
+        {
+            var sessions = (ConcurrentDictionary<string, object?>)sessionsField.GetValue(server)!;
+            var drained = true;
+            foreach (var sessionState in sessions.Values)
+            {
+                if (sessionState is null)
+                {
+                    continue;
+                }
+
+                var inflightField = sessionState.GetType().GetField("_inflight", BindingFlags.Instance | BindingFlags.NonPublic);
+                if (inflightField is null)
+                {
+                    continue;
+                }
+
+                var inflight = (ConcurrentDictionary<long, SessionFrame>)inflightField.GetValue(sessionState)!;
+                if (!inflight.IsEmpty)
+                {
+                    drained = false;
+                    break;
+                }
+            }
+
+            if (drained)
+            {
+                return;
+            }
+
+            await Task.Delay(10).ConfigureAwait(false);
+        }
+
+        throw new TimeoutException("Server sessions still have in-flight messages after the allotted timeout.");
+    }
+
+    private static int GetFreeTcpPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+}
+
+internal sealed class TestPersistentClientHost : IAsyncDisposable
+{
+    private readonly string _outboxPath;
+    private readonly ConcurrentQueue<string> _payloads = new();
+    private readonly List<long> _acknowledged = new();
+    private readonly List<(int Target, TaskCompletionSource Completion)> _messageWaiters = new();
+    private readonly List<(int Target, TaskCompletionSource Completion)> _ackWaiters = new();
+    private readonly List<(int Target, TaskCompletionSource Completion)> _connectionWaiters = new();
+    private readonly object _waiterLock = new();
+
+    private TcpClient? _activeClient;
+    private int _connectionCount;
+    private int _dropAckFlag;
+    private int _dropMessageFlag;
+
+    public TestPersistentClientHost(string host, int port, ResilientSessionOptions options)
+    {
+        _outboxPath = Path.Combine(Path.GetTempPath(), $"outbox-{Guid.NewGuid():N}.json");
+        Client = new PersistentSessionClient(host, port, OnClientConnectedAsync, options);
+        SetOutboxPath(Client, _outboxPath);
+    }
+
+    public PersistentSessionClient Client { get; }
+
+    public IReadOnlyCollection<string> ReceivedPayloads => _payloads.ToArray();
+
+    public IReadOnlyCollection<long> AcknowledgedMessageIds
+    {
+        get
+        {
+            lock (_acknowledged)
+            {
+                return _acknowledged.ToArray();
+            }
+        }
+    }
+
+    public int ConnectionCount => Volatile.Read(ref _connectionCount);
+
+    public Task StartAsync(CancellationToken cancellationToken)
+        => Client.StartAsync(cancellationToken);
+
+    public void DropNextAck() => Interlocked.Exchange(ref _dropAckFlag, 1);
+
+    public void DropNextMessage() => Interlocked.Exchange(ref _dropMessageFlag, 1);
+
+    public async Task WaitForMessageCountAsync(int count, TimeSpan timeout)
+    {
+        if (count <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count));
+        }
+
+        TaskCompletionSource waiter;
+        lock (_waiterLock)
+        {
+            if (_payloads.Count >= count)
+            {
+                return;
+            }
+
+            waiter = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _messageWaiters.Add((count, waiter));
+        }
+
+        await waiter.Task.WaitAsync(timeout).ConfigureAwait(false);
+    }
+
+    public async Task WaitForAckCountAsync(int count, TimeSpan timeout)
+    {
+        if (count <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count));
+        }
+
+        TaskCompletionSource waiter;
+        lock (_waiterLock)
+        {
+            if (_acknowledged.Count >= count)
+            {
+                return;
+            }
+
+            waiter = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _ackWaiters.Add((count, waiter));
+        }
+
+        await waiter.Task.WaitAsync(timeout).ConfigureAwait(false);
+    }
+
+    public async Task WaitForConnectionCountAsync(int count, TimeSpan timeout)
+    {
+        if (count <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count));
+        }
+
+        TaskCompletionSource waiter;
+        lock (_waiterLock)
+        {
+            if (_connectionCount >= count)
+            {
+                return;
+            }
+
+            waiter = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _connectionWaiters.Add((count, waiter));
+        }
+
+        await waiter.Task.WaitAsync(timeout).ConfigureAwait(false);
+    }
+
+    public async Task WaitForOutboxCountAsync(int expectedCount, TimeSpan timeout)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < timeout)
+        {
+            if (GetOutboxEntries().Count == expectedCount)
+            {
+                return;
+            }
+
+            await Task.Delay(10).ConfigureAwait(false);
+        }
+
+        throw new TimeoutException($"Outbox did not reach the expected count of {expectedCount} within the timeout window.");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await Client.DisposeAsync().ConfigureAwait(false);
+        var client = Interlocked.Exchange(ref _activeClient, null);
+        client?.Dispose();
+
+        if (File.Exists(_outboxPath))
+        {
+            try
+            {
+                File.Delete(_outboxPath);
+            }
+            catch
+            {
+                // ignore cleanup failures in tests
+            }
+        }
+    }
+
+    private Task OnClientConnectedAsync(PersistentSessionClient session, TcpClient client, CancellationToken cancellationToken)
+    {
+        Interlocked.Exchange(ref _activeClient, client);
+        var connections = Interlocked.Increment(ref _connectionCount);
+        NotifyWaiters(_connectionWaiters, connections);
+
+        _ = Task.Run(() => ReceiveLoopAsync(session, client, cancellationToken), cancellationToken);
+        return Task.CompletedTask;
+    }
+
+    private async Task ReceiveLoopAsync(PersistentSessionClient session, TcpClient client, CancellationToken cancellationToken)
+    {
+        var stream = client.GetStream();
+        var lengthBuffer = new byte[4];
+
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var result = await SessionFrameIO.ReadFrameAsync(stream, lengthBuffer, cancellationToken).ConfigureAwait(false);
+                if (!result.Success || result.Frame is null)
+                {
+                    break;
+                }
+
+                await HandleFrameAsync(session, client, result.Frame).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // shutdown requested
+        }
+        catch (Exception ex) when (ex is IOException or SocketException)
+        {
+            await Console.Error.WriteLineAsync($"Test receive loop terminated: {ex}").ConfigureAwait(false);
+        }
+        finally
+        {
+            if (ReferenceEquals(client, Interlocked.CompareExchange(ref _activeClient, null, client)))
+            {
+                client.Dispose();
+            }
+        }
+    }
+
+    private Task HandleFrameAsync(PersistentSessionClient session, TcpClient client, SessionFrame frame)
+    {
+        switch (frame.Kind)
+        {
+            case SessionFrameKind.Message when frame.Payload is not null && frame.Id is long messageId:
+                _payloads.Enqueue(frame.Payload);
+                session.RecordRemoteActivity();
+                NotifyWaiters(_messageWaiters, _payloads.Count);
+
+                if (Interlocked.Exchange(ref _dropMessageFlag, 0) == 1)
+                {
+                    DropClient(client);
+                    break;
+                }
+
+                session.EnqueueControlMessage(SessionFrame.CreateAck(messageId));
+                break;
+            case SessionFrameKind.Ack when frame.Id is long ackId:
+                session.RecordRemoteActivity();
+
+                if (Interlocked.Exchange(ref _dropAckFlag, 0) == 1)
+                {
+                    DropClient(client);
+                    break;
+                }
+
+                session.Acknowledge(ackId);
+                lock (_acknowledged)
+                {
+                    _acknowledged.Add(ackId);
+                }
+
+                NotifyWaiters(_ackWaiters, _acknowledged.Count);
+                break;
+            case SessionFrameKind.Ping:
+                session.RecordRemoteActivity();
+                session.EnqueueControlMessage(SessionFrame.CreatePong());
+                break;
+            case SessionFrameKind.Pong:
+            case SessionFrameKind.Auth:
+                session.RecordRemoteActivity();
+                break;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void DropClient(TcpClient client)
+    {
+        try
+        {
+            client.Dispose();
+        }
+        catch
+        {
+            // ignored for test cleanup
+        }
+    }
+
+    private IReadOnlyCollection<long> GetOutboxEntries()
+    {
+        var entriesField = typeof(PersistentSessionClient).GetField("_outboxEntries", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var entries = (System.Collections.IDictionary)entriesField.GetValue(Client)!;
+        var keys = new List<long>();
+        foreach (var key in entries.Keys)
+        {
+            if (key is long id)
+            {
+                keys.Add(id);
+            }
+        }
+
+        return keys;
+    }
+
+    private static void SetOutboxPath(PersistentSessionClient client, string path)
+    {
+        var field = typeof(PersistentSessionClient).GetField("_outboxPath", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        field.SetValue(client, path);
+    }
+
+    private static void NotifyWaiters(List<(int Target, TaskCompletionSource Completion)> waiters, int current)
+    {
+        if (waiters.Count == 0)
+        {
+            return;
+        }
+
+        List<TaskCompletionSource>? completed = null;
+        lock (_waiterLock)
+        {
+            for (var i = waiters.Count - 1; i >= 0; i--)
+            {
+                var (target, tcs) = waiters[i];
+                if (current >= target)
+                {
+                    completed ??= new List<TaskCompletionSource>();
+                    completed.Add(tcs);
+                    waiters.RemoveAt(i);
+                }
+            }
+        }
+
+        if (completed is null)
+        {
+            return;
+        }
+
+        foreach (var tcs in completed)
+        {
+            tcs.TrySetResult();
+        }
+    }
+}

--- a/tests/Yaref92.Events.UnitTests/Transports/PersistentSessionClientTests.cs
+++ b/tests/Yaref92.Events.UnitTests/Transports/PersistentSessionClientTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using NUnit.Framework;
+
+using Yaref92.Events.Transports;
+
+namespace Yaref92.Events.UnitTests.Transports;
+
+[TestFixture]
+public class PersistentSessionClientTests
+{
+    [Test]
+    public async Task Outbox_Persistence_RoundTrips_PendingEntries()
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), $"psc-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+        var outboxPath = Path.Combine(tempDirectory, "outbox.json");
+
+        try
+        {
+            long firstId;
+            long secondId;
+
+            await using (var writer = new PersistentSessionClient("localhost", 12345, (_, _, _) => Task.CompletedTask))
+            {
+                PersistentSessionClientTestHelper.OverrideOutboxPath(writer, outboxPath);
+                firstId = await writer.EnqueueEventAsync("first", CancellationToken.None).ConfigureAwait(false);
+                secondId = await writer.EnqueueEventAsync("second", CancellationToken.None).ConfigureAwait(false);
+                await PersistentSessionClientTestHelper.PersistOutboxAsync(writer, CancellationToken.None).ConfigureAwait(false);
+            }
+
+            await using var reader = new PersistentSessionClient("localhost", 12345, (_, _, _) => Task.CompletedTask);
+            PersistentSessionClientTestHelper.OverrideOutboxPath(reader, outboxPath);
+            await PersistentSessionClientTestHelper.LoadOutboxAsync(reader, CancellationToken.None).ConfigureAwait(false);
+
+            var snapshot = PersistentSessionClientTestHelper.GetOutboxSnapshot(reader);
+            snapshot.Should().ContainKey(firstId).WhoseValue.Should().Be("first");
+            snapshot.Should().ContainKey(secondId).WhoseValue.Should().Be("second");
+
+            var nextMessageId = PersistentSessionClientTestHelper.GetNextMessageId(reader);
+            nextMessageId.Should().BeGreaterOrEqualTo(secondId);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDirectory))
+            {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+        }
+    }
+
+    [Test]
+    public async Task HeartbeatLoop_Throws_When_Remote_Is_Inactive()
+    {
+        await using var client = new PersistentSessionClient(
+            "localhost",
+            12345,
+            (_, _, _) => Task.CompletedTask,
+            new ResilientSessionOptions
+            {
+                HeartbeatInterval = TimeSpan.Zero,
+                HeartbeatTimeout = TimeSpan.FromMilliseconds(10),
+            });
+
+        PersistentSessionClientTestHelper.SetLastRemoteActivity(client, DateTime.UtcNow - TimeSpan.FromSeconds(5));
+
+        Func<Task> act = () => PersistentSessionClientTestHelper.RunHeartbeatLoopAsync(client, CancellationToken.None);
+        await act.Should().ThrowAsync<IOException>().ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task BackoffDelay_GrowsExponentially_And_Respects_Maximum()
+    {
+        await using var client = new PersistentSessionClient(
+            "localhost",
+            12345,
+            (_, _, _) => Task.CompletedTask,
+            new ResilientSessionOptions
+            {
+                BackoffInitialDelay = TimeSpan.FromMilliseconds(5),
+                BackoffMaxDelay = TimeSpan.FromMilliseconds(40),
+            });
+
+        var attempt1 = PersistentSessionClientTestHelper.GetBackoffDelay(client, 1);
+        var attempt2 = PersistentSessionClientTestHelper.GetBackoffDelay(client, 2);
+        var attempt5 = PersistentSessionClientTestHelper.GetBackoffDelay(client, 5);
+
+        attempt1.Should().Be(TimeSpan.FromMilliseconds(5));
+        attempt2.Should().Be(TimeSpan.FromMilliseconds(10));
+        attempt5.Should().Be(TimeSpan.FromMilliseconds(40));
+    }
+}
+
+internal static class PersistentSessionClientTestHelper
+{
+    private static readonly FieldInfo OutboxPathField = typeof(PersistentSessionClient).GetField("_outboxPath", BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private static readonly FieldInfo OutboxEntriesField = typeof(PersistentSessionClient).GetField("_outboxEntries", BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private static readonly FieldInfo NextMessageIdField = typeof(PersistentSessionClient).GetField("_nextMessageId", BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private static readonly FieldInfo LastRemoteActivityField = typeof(PersistentSessionClient).GetField("_lastRemoteActivityTicks", BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private static readonly MethodInfo PersistOutboxMethod = typeof(PersistentSessionClient).GetMethod("PersistOutboxAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private static readonly MethodInfo LoadOutboxMethod = typeof(PersistentSessionClient).GetMethod("LoadOutboxAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private static readonly MethodInfo HeartbeatLoopMethod = typeof(PersistentSessionClient).GetMethod("RunHeartbeatLoopAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private static readonly MethodInfo BackoffDelayMethod = typeof(PersistentSessionClient).GetMethod("GetBackoffDelay", BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private static readonly Type OutboxEntryType = typeof(PersistentSessionClient).GetNestedType("OutboxEntry", BindingFlags.NonPublic)!;
+    private static readonly PropertyInfo PayloadProperty = OutboxEntryType.GetProperty("Payload", BindingFlags.Instance | BindingFlags.Public)!;
+
+    public static void OverrideOutboxPath(PersistentSessionClient client, string path)
+    {
+        OutboxPathField.SetValue(client, path);
+    }
+
+    public static async Task PersistOutboxAsync(PersistentSessionClient client, CancellationToken cancellationToken)
+    {
+        var task = (Task)PersistOutboxMethod.Invoke(client, new object[] { cancellationToken })!;
+        await task.ConfigureAwait(false);
+    }
+
+    public static async Task LoadOutboxAsync(PersistentSessionClient client, CancellationToken cancellationToken)
+    {
+        var task = (Task)LoadOutboxMethod.Invoke(client, new object[] { cancellationToken })!;
+        await task.ConfigureAwait(false);
+    }
+
+    public static Dictionary<long, string> GetOutboxSnapshot(PersistentSessionClient client)
+    {
+        var entries = (System.Collections.IDictionary)OutboxEntriesField.GetValue(client)!;
+        var snapshot = new Dictionary<long, string>();
+        foreach (var key in entries.Keys)
+        {
+            if (key is not long id)
+            {
+                continue;
+            }
+
+            var entry = entries[id];
+            var payload = (string)PayloadProperty.GetValue(entry)!;
+            snapshot[id] = payload;
+        }
+
+        return snapshot;
+    }
+
+    public static long GetNextMessageId(PersistentSessionClient client)
+    {
+        return (long)NextMessageIdField.GetValue(client)!;
+    }
+
+    public static void SetLastRemoteActivity(PersistentSessionClient client, DateTime timestamp)
+    {
+        LastRemoteActivityField.SetValue(client, timestamp.Ticks);
+    }
+
+    public static Task RunHeartbeatLoopAsync(PersistentSessionClient client, CancellationToken cancellationToken)
+    {
+        return (Task)HeartbeatLoopMethod.Invoke(client, new object[] { cancellationToken })!;
+    }
+
+    public static TimeSpan GetBackoffDelay(PersistentSessionClient client, int attempt)
+    {
+        return (TimeSpan)BackoffDelayMethod.Invoke(client, new object[] { attempt })!;
+    }
+}


### PR DESCRIPTION
## Summary
- add explicit integration coverage for persistent session reconnect/outbox replay and broadcast ack handling
- add deterministic unit tests for outbox persistence, heartbeat timeout detection, and exponential backoff calculations

## Testing
- `dotnet test` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_69034de7264083268d9d11228badb587