### PR TITLE
Update TCP transport unit tests for persistent sessions

### DIFF
--- a/tests/Yaref92.Events.UnitTests/Transports/TCPEventTransportUnitTests.cs
+++ b/tests/Yaref92.Events.UnitTests/Transports/TCPEventTransportUnitTests.cs
@@ -1,18 +1,16 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net;
-using System.Net.Sockets;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
 using FluentAssertions;
+using NUnit.Framework;
 
-using Yaref92.Events;
-using Yaref92.Events.Abstractions;
 using Yaref92.Events.Transports;
 
 namespace Yaref92.Events.UnitTests.Transports;
@@ -59,104 +57,114 @@ public class TCPEventTransportUnitTests
     }
 
     [Test]
-    public async Task PublishAsync_WhenWriteFails_RaisesPublishFailureAndRemovesClient()
+    public async Task PublishAsync_WithPersistentSessions_EnqueuesPayload_ForEachSession()
     {
-        var aggregator = new EventAggregator();
-        using var transport = new TestableTCPEventTransport(aggregator);
+        // Arrange
+        using var transport = new TCPEventTransport(0);
+        var sessions = GetPersistentSessionsDictionary(transport);
 
-        var publishFailureTcs = new TaskCompletionSource<PublishFailed>(TaskCreationOptions.RunContinuationsAsynchronously);
-        aggregator.SubscribeToEventType(new CapturePublishFailedSubscriber(publishFailureTcs));
-
-        var (failingClient, serverClient) = await CreateConnectedClientPairAsync().ConfigureAwait(false);
-        var endpoint = failingClient.Client.RemoteEndPoint;
-        transport.AddFailingClient(failingClient, new IOException("Simulated write failure."));
-
-        GetClientsDictionary(transport).Count.Should().Be(1, "the tracked client should still be present before publishing");
-
+        var tempDirectory = CreateTempDirectory();
         try
         {
-            Func<Task> act = () => transport.PublishAsync(new DummyEvent());
-            var aggregateException = await act.Should().ThrowAsync<AggregateException>();
-            aggregateException.Which.InnerExceptions.Should().ContainSingle();
+            var sessionA = CreateSession(tempDirectory);
+            var sessionB = CreateSession(tempDirectory);
+            sessions.TryAdd("peer-a", sessionA);
+            sessions.TryAdd("peer-b", sessionB);
 
-            var failure = await publishFailureTcs.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
-            failure.Endpoint.Should().Be(endpoint);
-            failure.Exception.Should().BeOfType<IOException>();
+            // Act
+            await transport.PublishAsync(new DummyEvent()).ConfigureAwait(false);
 
-            GetClientsDictionary(transport).Should().BeEmpty();
+            // Assert
+            var snapshotA = PersistentSessionClientTestHelper.GetOutboxSnapshot(sessionA);
+            var snapshotB = PersistentSessionClientTestHelper.GetOutboxSnapshot(sessionB);
+
+            snapshotA.Should().HaveCount(1);
+            snapshotB.Should().HaveCount(1);
+            snapshotA.Values.Single().Should().Be(snapshotB.Values.Single());
         }
         finally
         {
-            serverClient.Dispose();
+            await DisposeSessionsAsync(sessions.Values).ConfigureAwait(false);
+            DeleteTempDirectory(tempDirectory);
         }
     }
 
     [Test]
-    public async Task PublishAsync_WhenMultipleClientsFail_AggregatesAllExceptions()
+    public async Task PublishAsync_WhenPersistentSessionThrows_PropagatesException()
     {
-        var aggregator = new EventAggregator();
-        using var transport = new TestableTCPEventTransport(aggregator);
+        using var transport = new TCPEventTransport(0);
+        var sessions = GetPersistentSessionsDictionary(transport);
 
-        var (failingClient1, serverClient1) = await CreateConnectedClientPairAsync().ConfigureAwait(false);
-        var (failingClient2, serverClient2) = await CreateConnectedClientPairAsync().ConfigureAwait(false);
-
-        var endpoint1 = failingClient1.Client.RemoteEndPoint;
-        var endpoint2 = failingClient2.Client.RemoteEndPoint;
-
-        transport.AddFailingClient(failingClient1, new IOException("First write failure."));
-        transport.AddFailingClient(failingClient2, new IOException("Second write failure."));
-
-        var publishFailures = new CountingPublishFailedSubscriber(expectedCount: 2);
-        aggregator.SubscribeToEventType(publishFailures);
-
-        GetClientsDictionary(transport).Count.Should().Be(2, "both clients should be tracked before the publish attempt");
-
+        var tempDirectory = CreateTempDirectory();
         try
         {
+            var session = CreateSession(tempDirectory);
+            sessions.TryAdd("peer", session);
+            await session.DisposeAsync().ConfigureAwait(false);
+
             Func<Task> act = () => transport.PublishAsync(new DummyEvent());
-            var aggregateException = await act.Should().ThrowAsync<AggregateException>();
-            aggregateException.Which.InnerExceptions.Should().HaveCount(2);
+            await act.Should().ThrowAsync<ObjectDisposedException>().ConfigureAwait(false);
 
-            await publishFailures.WaitForCountAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
-
-            publishFailures.Failures.Should().HaveCount(2);
-            publishFailures.Failures.Select(f => f.Endpoint).Should().BeEquivalentTo(new[] { endpoint1, endpoint2 });
-            publishFailures.Failures.Should().AllSatisfy(f => f.Exception.Should().BeOfType<IOException>());
-
-            GetClientsDictionary(transport).Should().BeEmpty();
+            sessions.Should().ContainKey("peer");
         }
         finally
         {
-            serverClient1.Dispose();
-            serverClient2.Dispose();
+            await DisposeSessionsAsync(sessions.Values).ConfigureAwait(false);
+            DeleteTempDirectory(tempDirectory);
         }
     }
 
-    private static ConcurrentDictionary<TcpClient, byte> GetClientsDictionary(TCPEventTransport transport)
+    private static ConcurrentDictionary<string, PersistentSessionClient> GetPersistentSessionsDictionary(TCPEventTransport transport)
     {
-        var clientsField = typeof(TCPEventTransport).GetField("_clients", BindingFlags.NonPublic | BindingFlags.Instance);
-        return (ConcurrentDictionary<TcpClient, byte>)clientsField!.GetValue(transport)!;
+        var field = typeof(TCPEventTransport).GetField("_persistentSessions", BindingFlags.Instance | BindingFlags.NonPublic);
+        return (ConcurrentDictionary<string, PersistentSessionClient>)field!.GetValue(transport)!;
     }
 
-    private static async Task<(TcpClient Client, TcpClient Server)> CreateConnectedClientPairAsync()
+    private static PersistentSessionClient CreateSession(string tempDirectory)
     {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
+        var session = new PersistentSessionClient("localhost", 12345, (_, _, _) => Task.CompletedTask);
+        var path = Path.Combine(tempDirectory, $"outbox-{Guid.NewGuid():N}.json");
+        PersistentSessionClientTestHelper.OverrideOutboxPath(session, path);
+        return session;
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"tcp-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void DeleteTempDirectory(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return;
+        }
 
         try
         {
-            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            var acceptTask = listener.AcceptTcpClientAsync();
-
-            var client = new TcpClient();
-            await client.ConnectAsync(IPAddress.Loopback, port).ConfigureAwait(false);
-            var server = await acceptTask.ConfigureAwait(false);
-
-            return (client, server);
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
         }
-        finally
+        catch (IOException)
         {
-            listener.Stop();
+            // ignore cleanup failures in tests
+        }
+    }
+
+    private static async Task DisposeSessionsAsync(IEnumerable<PersistentSessionClient> sessions)
+    {
+        foreach (var session in sessions.ToArray())
+        {
+            if (session is null)
+            {
+                continue;
+            }
+
+            await session.DisposeAsync().ConfigureAwait(false);
         }
     }
 
@@ -166,94 +174,4 @@ public class TCPEventTransportUnitTests
         public string? Json { get; set; }
     }
 
-    private sealed class TestableTCPEventTransport : TCPEventTransport
-    {
-        private readonly ConcurrentDictionary<TcpClient, Exception> _failures = new();
-
-        public TestableTCPEventTransport(IEventAggregator eventAggregator)
-            : base(0, eventAggregator: eventAggregator)
-        {
-        }
-
-        public void AddFailingClient(TcpClient client, Exception exception)
-        {
-            if (client is null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
-
-            if (exception is null)
-            {
-                throw new ArgumentNullException(nameof(exception));
-            }
-
-            var clientsField = typeof(TCPEventTransport).GetField("_clients", BindingFlags.NonPublic | BindingFlags.Instance);
-            var clients = (ConcurrentDictionary<TcpClient, byte>)clientsField!.GetValue(this)!;
-            if (!clients.TryAdd(client, 0))
-            {
-                throw new InvalidOperationException("The TCP client is already tracked by the transport.");
-            }
-
-            _failures[client] = exception;
-        }
-
-        protected Task WriteToClientAsync(
-            TcpClient client,
-            ReadOnlyMemory<byte> lengthPrefix,
-            ReadOnlyMemory<byte> payload,
-            CancellationToken cancellationToken)
-        {
-            if (_failures.TryGetValue(client, out var exception))
-            {
-                throw exception;
-            }
-
-            return Task.CompletedTask;
-        }
-    }
-
-    private sealed class CapturePublishFailedSubscriber : IEventSubscriber<PublishFailed>
-    {
-        private readonly TaskCompletionSource<PublishFailed> _tcs;
-
-        public CapturePublishFailedSubscriber(TaskCompletionSource<PublishFailed> tcs)
-        {
-            _tcs = tcs;
-        }
-
-        public void OnNext(PublishFailed domainEvent)
-        {
-            _tcs.TrySetResult(domainEvent);
-        }
-    }
-
-    private sealed class CountingPublishFailedSubscriber : IEventSubscriber<PublishFailed>
-    {
-        private readonly TaskCompletionSource<bool> _tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        private readonly int _expectedCount;
-        private readonly ConcurrentBag<PublishFailed> _failures = new();
-        private int _count;
-
-        public CountingPublishFailedSubscriber(int expectedCount)
-        {
-            _expectedCount = expectedCount;
-        }
-
-        public IReadOnlyCollection<PublishFailed> Failures => _failures.ToArray();
-
-        public void OnNext(PublishFailed domainEvent)
-        {
-            _failures.Add(domainEvent);
-            if (Interlocked.Increment(ref _count) >= _expectedCount)
-            {
-                _tcs.TrySetResult(true);
-            }
-        }
-
-        public async Task WaitForCountAsync(TimeSpan timeout)
-        {
-            using var cts = new CancellationTokenSource(timeout);
-            await _tcs.Task.WaitAsync(cts.Token).ConfigureAwait(false);
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- update TCP transport unit tests to exercise the persistent session-based transport implementation
- add helper utilities for creating and cleaning up persistent session clients during tests

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_69036de9b3e48326acdf4566324c3479