### PR TITLE
Handle TCP publish failures via async subscriber

### DIFF
--- a/src/Yaref92.Events/Transports/PublishFailedHandler.cs
+++ b/src/Yaref92.Events/Transports/PublishFailedHandler.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Yaref92.Events.Abstractions;
+
+namespace Yaref92.Events.Transports;
+
+/// <summary>
+/// Default asynchronous handler for <see cref="PublishFailed"/> events.
+/// Logs the failure details so that operators can take action.
+/// </summary>
+public sealed class PublishFailedHandler : IAsyncEventSubscriber<PublishFailed>
+{
+    private readonly Func<PublishFailed, CancellationToken, Task> _handler;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PublishFailedHandler"/> class.
+    /// </summary>
+    /// <param name="handler">
+    /// Optional delegate used to process <see cref="PublishFailed"/> events. When not supplied the
+    /// handler writes a diagnostic message to <see cref="Console.Error"/>.
+    /// </param>
+    public PublishFailedHandler(Func<PublishFailed, CancellationToken, Task>? handler = null)
+    {
+        _handler = handler ?? LogFailureAsync;
+    }
+
+    /// <inheritdoc />
+    public Task OnNextAsync(PublishFailed domainEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(domainEvent);
+        return _handler(domainEvent, cancellationToken);
+    }
+
+    private static Task LogFailureAsync(PublishFailed domainEvent, CancellationToken cancellationToken)
+    {
+        var endpoint = domainEvent.Endpoint is null
+            ? "unknown endpoint"
+            : domainEvent.Endpoint.ToString();
+
+        var message = $"Publish to {endpoint} failed: {domainEvent.Exception}";
+        return Console.Error.WriteLineAsync(message);
+    }
+}

--- a/src/Yaref92.Events/Transports/TCPEventTransport.cs
+++ b/src/Yaref92.Events/Transports/TCPEventTransport.cs
@@ -42,6 +42,7 @@ public class TCPEventTransport : IEventTransport, IAsyncDisposable
         };
 
         _eventAggregator?.RegisterEventType<PublishFailed>();
+        _eventAggregator?.SubscribeToEventType(new PublishFailedHandler());
     }
 
     public Task StartListeningAsync(CancellationToken cancellationToken = default)

--- a/tests/Yaref92.Events.UnitTests/Transports/PersistentSessionClientTests.cs
+++ b/tests/Yaref92.Events.UnitTests/Transports/PersistentSessionClientTests.cs
@@ -108,6 +108,7 @@ internal static class PersistentSessionClientTestHelper
     private static readonly MethodInfo LoadOutboxMethod = typeof(PersistentSessionClient).GetMethod("LoadOutboxAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
     private static readonly MethodInfo HeartbeatLoopMethod = typeof(PersistentSessionClient).GetMethod("RunHeartbeatLoopAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
     private static readonly MethodInfo BackoffDelayMethod = typeof(PersistentSessionClient).GetMethod("GetBackoffDelay", BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private static readonly MethodInfo NotifySendFailureMethod = typeof(PersistentSessionClient).GetMethod("NotifySendFailure", BindingFlags.Instance | BindingFlags.NonPublic)!;
     private static readonly Type OutboxEntryType = typeof(PersistentSessionClient).GetNestedType("OutboxEntry", BindingFlags.NonPublic)!;
     private static readonly PropertyInfo PayloadProperty = OutboxEntryType.GetProperty("Payload", BindingFlags.Instance | BindingFlags.Public)!;
 
@@ -165,5 +166,10 @@ internal static class PersistentSessionClientTestHelper
     public static TimeSpan GetBackoffDelay(PersistentSessionClient client, int attempt)
     {
         return (TimeSpan)BackoffDelayMethod.Invoke(client, new object[] { attempt })!;
+    }
+
+    public static void NotifySendFailure(PersistentSessionClient client, Exception exception)
+    {
+        NotifySendFailureMethod.Invoke(client, new object[] { exception });
     }
 }

--- a/tests/Yaref92.Events.UnitTests/Transports/TCPEventTransportUnitTests.cs
+++ b/tests/Yaref92.Events.UnitTests/Transports/TCPEventTransportUnitTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading;
@@ -11,6 +12,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using NUnit.Framework;
 
+using Yaref92.Events.Abstractions;
 using Yaref92.Events.Transports;
 
 namespace Yaref92.Events.UnitTests.Transports;
@@ -114,6 +116,30 @@ public class TCPEventTransportUnitTests
         }
     }
 
+    [Test]
+    public void NotifySendFailure_PublishesEventToRegisteredSubscriber()
+    {
+        // Arrange
+        var aggregator = new FakeEventAggregator();
+        using var transport = new TCPEventTransport(0, eventAggregator: aggregator);
+        var session = new PersistentSessionClient(
+            "localhost",
+            12345,
+            (_, _, _) => Task.CompletedTask,
+            eventAggregator: aggregator);
+        var exception = new IOException("boom");
+
+        // Act
+        PersistentSessionClientTestHelper.NotifySendFailure(session, exception);
+
+        // Assert
+        aggregator.PublishFailedHandlerExecuted.Should().BeTrue();
+        aggregator.PublishedFailures.Should().ContainSingle();
+        var failure = aggregator.PublishedFailures.Single();
+        failure.Endpoint.Should().BeEquivalentTo(session.RemoteEndPoint);
+        failure.Exception.Should().Be(exception);
+    }
+
     private static ConcurrentDictionary<string, PersistentSessionClient> GetPersistentSessionsDictionary(TCPEventTransport transport)
     {
         var field = typeof(TCPEventTransport).GetField("_persistentSessions", BindingFlags.Instance | BindingFlags.NonPublic);
@@ -165,6 +191,89 @@ public class TCPEventTransportUnitTests
             }
 
             await session.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private sealed class FakeEventAggregator : IEventAggregator
+    {
+        private readonly List<IEventSubscriber> _subscribers = new();
+        private readonly List<IAsyncEventSubscriber<PublishFailed>> _publishFailedSubscribers = new();
+
+        public bool PublishFailedHandlerExecuted { get; private set; }
+
+        public List<PublishFailed> PublishedFailures { get; } = new();
+
+        public ISet<Type> EventTypes { get; } = new HashSet<Type>();
+
+        public IReadOnlyCollection<IEventSubscriber> Subscribers => _subscribers;
+
+        public bool RegisterEventType<T>() where T : class, IDomainEvent
+        {
+            return EventTypes.Add(typeof(T));
+        }
+
+        public void PublishEvent<T>(T domainEvent) where T : class, IDomainEvent
+        {
+            throw new NotSupportedException();
+        }
+
+        public void SubscribeToEventType<T>(IEventSubscriber<T> subscriber) where T : class, IDomainEvent
+        {
+            throw new NotSupportedException();
+        }
+
+        public void SubscribeToEventType<T>(IAsyncEventSubscriber<T> subscriber) where T : class, IDomainEvent
+        {
+            if (subscriber is null)
+            {
+                throw new ArgumentNullException(nameof(subscriber));
+            }
+
+            if (subscriber is IEventSubscriber eventSubscriber)
+            {
+                _subscribers.Add(eventSubscriber);
+            }
+
+            if (subscriber is IAsyncEventSubscriber<PublishFailed> publishFailedSubscriber)
+            {
+                _publishFailedSubscribers.Add(publishFailedSubscriber);
+            }
+        }
+
+        public void UnsubscribeFromEventType<T>(IEventSubscriber<T> subscriber) where T : class, IDomainEvent
+        {
+            throw new NotSupportedException();
+        }
+
+        public void UnsubscribeFromEventType<T>(IAsyncEventSubscriber<T> subscriber) where T : class, IDomainEvent
+        {
+            if (subscriber is IEventSubscriber eventSubscriber)
+            {
+                _subscribers.Remove(eventSubscriber);
+            }
+
+            if (subscriber is IAsyncEventSubscriber<PublishFailed> publishFailedSubscriber)
+            {
+                _publishFailedSubscribers.Remove(publishFailedSubscriber);
+            }
+        }
+
+        public Task PublishEventAsync<T>(T domainEvent, CancellationToken cancellationToken = default) where T : class, IDomainEvent
+        {
+            if (domainEvent is PublishFailed publishFailed)
+            {
+                PublishedFailures.Add(publishFailed);
+
+                var tasks = _publishFailedSubscribers.Select(async subscriber =>
+                {
+                    await subscriber.OnNextAsync(publishFailed, cancellationToken).ConfigureAwait(false);
+                    PublishFailedHandlerExecuted = true;
+                });
+
+                return Task.WhenAll(tasks);
+            }
+
+            return Task.CompletedTask;
         }
     }
 


### PR DESCRIPTION
## Summary
- add a PublishFailedHandler asynchronous subscriber that logs failures by default
- register the new handler when TCPEventTransport is created so PublishFailed events are observed
- extend unit tests to expose NotifySendFailure and verify the handler executes through a fake aggregator

## Testing
- dotnet test *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_6904b14288648326aa8339e77e1a4935