### PR TITLE
Add MessageReceived event and aggregator wiring for TCP transport

### DIFF
--- a/src/Yaref92.Events/Transports/MessageReceived.cs
+++ b/src/Yaref92.Events/Transports/MessageReceived.cs
@@ -1,0 +1,35 @@
+using System;
+
+using Yaref92.Events;
+
+namespace Yaref92.Events.Transports;
+
+/// <summary>
+/// Domain event emitted when a serialized payload is received from a remote session.
+/// </summary>
+public sealed class MessageReceived : DomainEventBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessageReceived"/> class.
+    /// </summary>
+    /// <param name="sessionKey">The unique key identifying the remote session.</param>
+    /// <param name="payload">The serialized payload received from the remote session.</param>
+    /// <param name="dateTimeOccurredUtc">Optional UTC timestamp representing when the event occurred.</param>
+    /// <param name="eventId">Optional identifier for the event.</param>
+    public MessageReceived(string sessionKey, string payload, DateTime dateTimeOccurredUtc = default, Guid eventId = default)
+        : base(dateTimeOccurredUtc, eventId)
+    {
+        SessionKey = sessionKey ?? throw new ArgumentNullException(nameof(sessionKey));
+        Payload = payload ?? throw new ArgumentNullException(nameof(payload));
+    }
+
+    /// <summary>
+    /// Gets the unique key that identifies the remote session from which the payload was received.
+    /// </summary>
+    public string SessionKey { get; }
+
+    /// <summary>
+    /// Gets the serialized payload that was received from the remote session.
+    /// </summary>
+    public string Payload { get; }
+}

--- a/tests/Yaref92.Events.IntegrationTests/ResilientSessionIntegrationTests.cs
+++ b/tests/Yaref92.Events.IntegrationTests/ResilientSessionIntegrationTests.cs
@@ -33,7 +33,7 @@ public class ResilientSessionIntegrationTests
         var firstDeliveryTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var replayDeliveryTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        server.MessageReceived += async (_, payload, _) =>
+        server.SetMessageReceivedHandler((_, payload, _) =>
         {
             deliveries.Add(payload);
             if (deliveries.Count == 1)
@@ -45,8 +45,8 @@ public class ResilientSessionIntegrationTests
                 replayDeliveryTcs.TrySetResult();
             }
 
-            await Task.CompletedTask;
-        };
+            return Task.CompletedTask;
+        });
 
         await server.StartAsync().ConfigureAwait(false);
 


### PR DESCRIPTION
## Summary
- introduce a MessageReceived domain event that captures the session key and payload
- notify the event aggregator and local subscribers when TCP messages arrive from servers or persistent sessions
- update ResilientTcpServer to use an injected handler instead of exposing a MessageReceived event
- extend unit tests to cover the new MessageReceived publishing behavior and adjust integration tests

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_6904b7ffe59c83268e0203df286debb3