### PR TITLE
Add gRPC transport contract project

### DIFF
--- a/Yaref92.Events.ci.slnf
+++ b/Yaref92.Events.ci.slnf
@@ -3,6 +3,7 @@
     "path": "Yaref92.Events.sln",
     "projects": [
       "src/Yaref92.Events.Rx/Yaref92.Events.Rx.csproj",
+      "src/Yaref92.Events.Transport.Grpc/Yaref92.Events.Transport.Grpc.csproj",
       "src/Yaref92.Events/Yaref92.Events.csproj",
       "tests/Yaref92.Events.IntegrationTests/Yaref92.Events.IntegrationTests.csproj",
       "tests/Yaref92.Events.Rx.UnitTests/Yaref92.Events.Rx.UnitTests.csproj",

--- a/Yaref92.Events.sln
+++ b/Yaref92.Events.sln
@@ -22,6 +22,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{D09D
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventMessenger", "samples\EventMessenger\EventMessenger.csproj", "{7901D738-F48A-4D3A-8E07-DF553E408568}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{166B8781-AEFA-4B62-A2A7-53E5E85B2FE1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yaref92.Events.Transport.Grpc", "src\Yaref92.Events.Transport.Grpc\Yaref92.Events.Transport.Grpc.csproj", "{F6A9E212-A7C9-4568-8B89-BD0C122EA109}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -54,12 +58,17 @@ Global
 		{7901D738-F48A-4D3A-8E07-DF553E408568}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7901D738-F48A-4D3A-8E07-DF553E408568}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7901D738-F48A-4D3A-8E07-DF553E408568}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{F6A9E212-A7C9-4568-8B89-BD0C122EA109}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6A9E212-A7C9-4568-8B89-BD0C122EA109}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6A9E212-A7C9-4568-8B89-BD0C122EA109}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6A9E212-A7C9-4568-8B89-BD0C122EA109}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{7901D738-F48A-4D3A-8E07-DF553E408568} = {D09DD89D-92F9-4A0B-912C-1478E8764E39}
+		{F6A9E212-A7C9-4568-8B89-BD0C122EA109} = {166B8781-AEFA-4B62-A2A7-53E5E85B2FE1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3DF92ACB-BB74-4ED1-A388-F7FB058FBF4B}

--- a/src/Yaref92.Events.Transport.Grpc/Models/GrpcSessionFrame.cs
+++ b/src/Yaref92.Events.Transport.Grpc/Models/GrpcSessionFrame.cs
@@ -1,0 +1,184 @@
+using System.Globalization;
+using Yaref92.Events.Transport.Grpc.Protos;
+using Yaref92.Events.Transports.Events;
+
+namespace Yaref92.Events.Transport.Grpc.Models;
+
+internal enum GrpcSessionFrameKind
+{
+    Auth,
+    Ping,
+    Pong,
+    Message,
+    Ack,
+}
+
+internal sealed record GrpcReconnectToken(string SessionKey, string Token);
+
+internal sealed record GrpcAuthPayload(string SessionToken, string? Secret, GrpcReconnectToken? ReconnectToken);
+
+internal sealed record GrpcMessagePayload(Guid EventId, EventEnvelope Envelope, string? DeduplicationId)
+{
+    public string DeduplicationCorrelation => DeduplicationId ?? EventId.ToString("D", CultureInfo.InvariantCulture);
+}
+
+internal sealed record GrpcAckPayload(Guid EventId, string? DeduplicationId)
+{
+    public string DeduplicationCorrelation => DeduplicationId ?? EventId.ToString("D", CultureInfo.InvariantCulture);
+}
+
+internal sealed record GrpcSessionFrame(
+    GrpcSessionFrameKind Kind,
+    string? SessionId,
+    GrpcAuthPayload? Auth,
+    GrpcMessagePayload? Message,
+    GrpcAckPayload? Ack)
+{
+    public static GrpcSessionFrame FromProto(SessionFrame frame)
+    {
+        return frame.FrameCase switch
+        {
+            SessionFrame.FrameOneofCase.Auth => CreateAuthFrame(frame),
+            SessionFrame.FrameOneofCase.Ping => new GrpcSessionFrame(GrpcSessionFrameKind.Ping, frame.SessionId, null, null, null),
+            SessionFrame.FrameOneofCase.Pong => new GrpcSessionFrame(GrpcSessionFrameKind.Pong, frame.SessionId, null, null, null),
+            SessionFrame.FrameOneofCase.Message => CreateMessageFrame(frame),
+            SessionFrame.FrameOneofCase.Ack => CreateAckFrame(frame),
+            _ => throw new InvalidOperationException("Unknown session frame kind"),
+        };
+    }
+
+    public static SessionFrame ToProto(GrpcSessionFrame frame)
+    {
+        SessionFrame protoFrame = new()
+        {
+            SessionId = frame.SessionId ?? string.Empty,
+        };
+
+        switch (frame.Kind)
+        {
+            case GrpcSessionFrameKind.Auth:
+                if (frame.Auth is null)
+                {
+                    throw new InvalidOperationException("Auth payload is required for AUTH frames.");
+                }
+
+                protoFrame.Auth = new AuthFrame
+                {
+                    SessionToken = frame.Auth.SessionToken,
+                    Secret = frame.Auth.Secret ?? string.Empty,
+                };
+
+                if (frame.Auth.ReconnectToken is not null)
+                {
+                    protoFrame.Auth.ReconnectToken = new ReconnectToken
+                    {
+                        SessionKey = frame.Auth.ReconnectToken.SessionKey,
+                        Token = frame.Auth.ReconnectToken.Token,
+                    };
+                }
+
+                break;
+            case GrpcSessionFrameKind.Ping:
+                protoFrame.Ping = new PingFrame();
+                break;
+            case GrpcSessionFrameKind.Pong:
+                protoFrame.Pong = new PongFrame();
+                break;
+            case GrpcSessionFrameKind.Message:
+                if (frame.Message is null)
+                {
+                    throw new InvalidOperationException("Message payload is required for MSG frames.");
+                }
+
+                protoFrame.Message = new MessageFrame
+                {
+                    EventId = frame.Message.EventId.ToString("D", CultureInfo.InvariantCulture),
+                    DeduplicationId = frame.Message.DeduplicationCorrelation,
+                    Envelope = new Protos.EventEnvelope
+                    {
+                        EventId = frame.Message.Envelope.EventId.ToString("D", CultureInfo.InvariantCulture),
+                        TypeName = frame.Message.Envelope.TypeName ?? string.Empty,
+                        EventJson = frame.Message.Envelope.EventJson ?? string.Empty,
+                    },
+                };
+
+                break;
+            case GrpcSessionFrameKind.Ack:
+                if (frame.Ack is null)
+                {
+                    throw new InvalidOperationException("Ack payload is required for ACK frames.");
+                }
+
+                protoFrame.Ack = new AckFrame
+                {
+                    EventId = frame.Ack.EventId.ToString("D", CultureInfo.InvariantCulture),
+                    DeduplicationId = frame.Ack.DeduplicationCorrelation,
+                };
+
+                break;
+            default:
+                throw new InvalidOperationException("Unknown session frame kind");
+        }
+
+        return protoFrame;
+    }
+
+    private static GrpcSessionFrame CreateAuthFrame(SessionFrame frame)
+    {
+        AuthFrame auth = frame.Auth;
+        GrpcReconnectToken? reconnect = null;
+
+        if (auth.ReconnectToken is not null && !string.IsNullOrWhiteSpace(auth.ReconnectToken.SessionKey))
+        {
+            reconnect = new GrpcReconnectToken(auth.ReconnectToken.SessionKey, auth.ReconnectToken.Token);
+        }
+
+        return new GrpcSessionFrame(
+            GrpcSessionFrameKind.Auth,
+            frame.SessionId,
+            new GrpcAuthPayload(auth.SessionToken, string.IsNullOrWhiteSpace(auth.Secret) ? null : auth.Secret, reconnect),
+            null,
+            null);
+    }
+
+    private static GrpcSessionFrame CreateMessageFrame(SessionFrame frame)
+    {
+        MessageFrame message = frame.Message;
+        Guid eventId = ParseGuid(message.EventId, nameof(message.EventId));
+        Protos.EventEnvelope envelope = message.Envelope ?? throw new InvalidOperationException("Message frames require an envelope");
+
+        EventEnvelope domainEnvelope = new(
+            ParseGuid(envelope.EventId, nameof(envelope.EventId)),
+            string.IsNullOrWhiteSpace(envelope.TypeName) ? null : envelope.TypeName,
+            string.IsNullOrWhiteSpace(envelope.EventJson) ? null : envelope.EventJson);
+
+        return new GrpcSessionFrame(
+            GrpcSessionFrameKind.Message,
+            frame.SessionId,
+            null,
+            new GrpcMessagePayload(eventId, domainEnvelope, string.IsNullOrWhiteSpace(message.DeduplicationId) ? null : message.DeduplicationId),
+            null);
+    }
+
+    private static GrpcSessionFrame CreateAckFrame(SessionFrame frame)
+    {
+        AckFrame ack = frame.Ack;
+
+        return new GrpcSessionFrame(
+            GrpcSessionFrameKind.Ack,
+            frame.SessionId,
+            null,
+            null,
+            new GrpcAckPayload(ParseGuid(ack.EventId, nameof(ack.EventId)), string.IsNullOrWhiteSpace(ack.DeduplicationId) ? null : ack.DeduplicationId));
+    }
+
+    private static Guid ParseGuid(string value, string fieldName)
+    {
+        if (Guid.TryParse(value, out Guid parsed))
+        {
+            return parsed;
+        }
+
+        throw new InvalidOperationException($"Field '{fieldName}' must be a valid GUID string.");
+    }
+}

--- a/src/Yaref92.Events.Transport.Grpc/Protos/event_envelope.proto
+++ b/src/Yaref92.Events.Transport.Grpc/Protos/event_envelope.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package yaref92.events.transport.v1;
+
+option csharp_namespace = "Yaref92.Events.Transport.Grpc.Protos";
+
+message EventEnvelope {
+  string event_id = 1;
+  string type_name = 2;
+  string event_json = 3;
+}

--- a/src/Yaref92.Events.Transport.Grpc/Protos/reconnect.proto
+++ b/src/Yaref92.Events.Transport.Grpc/Protos/reconnect.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package yaref92.events.transport.v1;
+
+option csharp_namespace = "Yaref92.Events.Transport.Grpc.Protos";
+
+message ReconnectToken {
+  string session_key = 1;
+  string token = 2;
+}

--- a/src/Yaref92.Events.Transport.Grpc/Protos/session_frames.proto
+++ b/src/Yaref92.Events.Transport.Grpc/Protos/session_frames.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+
+package yaref92.events.transport.v1;
+
+option csharp_namespace = "Yaref92.Events.Transport.Grpc.Protos";
+
+import "event_envelope.proto";
+import "reconnect.proto";
+
+message AuthFrame {
+  string session_token = 1;
+  string secret = 2;
+  ReconnectToken reconnect_token = 3;
+}
+
+message PingFrame {}
+
+message PongFrame {}
+
+message MessageFrame {
+  string event_id = 1;
+  EventEnvelope envelope = 2;
+  string deduplication_id = 3;
+}
+
+message AckFrame {
+  string event_id = 1;
+  string deduplication_id = 2;
+}
+
+message SessionFrame {
+  string session_id = 1;
+  oneof frame {
+    AuthFrame auth = 2;
+    PingFrame ping = 3;
+    PongFrame pong = 4;
+    MessageFrame message = 5;
+    AckFrame ack = 6;
+  }
+}

--- a/src/Yaref92.Events.Transport.Grpc/Yaref92.Events.Transport.Grpc.csproj
+++ b/src/Yaref92.Events.Transport.Grpc/Yaref92.Events.Transport.Grpc.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" Version="3.27.1" />
+    <PackageReference Include="Grpc.Tools" Version="2.66.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\\Yaref92.Events\\Yaref92.Events.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="Protos\\session_frames.proto" GrpcServices="None" />
+    <Protobuf Include="Protos\\event_envelope.proto" GrpcServices="None" />
+    <Protobuf Include="Protos\\reconnect.proto" GrpcServices="None" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add a Yaref92.Events.Transport.Grpc project containing proto schemas for session frames, envelopes, and reconnect tokens
- generate gRPC tooling inputs and internal frame models that capture event, ACK, and deduplication semantics
- include the new transport project in the solution and CI solution filter

## Testing
- dotnet build Yaref92.Events.sln *(fails: sample Maui workloads unavailable in the environment)*
- dotnet build src/Yaref92.Events.Transport.Grpc/Yaref92.Events.Transport.Grpc.csproj *(fails: nuget.org unreachable from the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942bd0334248326be5aaa084a9568a8)