### PR TITLE
Report peer connection failures in sample UI

### DIFF
--- a/samples/EventMessenger/ViewModels/MainViewModel.cs
+++ b/samples/EventMessenger/ViewModels/MainViewModel.cs
@@ -90,8 +90,17 @@ public class MainViewModel : INotifyPropertyChanged
             return;
         }
 
-        await _transport.ConnectToPeerAsync(PeerHost, port);
-        await ShowToastAsync($"Connected to {PeerHost}:{PeerPort}");
+        try
+        {
+            await _transport.ConnectToPeerAsync(PeerHost, port);
+            await ShowToastAsync($"Connected to {PeerHost}:{PeerPort}");
+        }
+        catch (Exception ex)
+        {
+            var message = FormatExceptionMessage(ex);
+            await Console.Error.WriteLineAsync($"Failed to connect to {PeerHost}:{PeerPort}. {message}");
+            await ShowToastAsync($"Failed to connect to {PeerHost}:{PeerPort}. {message}");
+        }
     }
 
     public async Task SendMessageAsync()
@@ -147,6 +156,14 @@ public class MainViewModel : INotifyPropertyChanged
                 await page.DisplayAlert("Notification", message, "OK");
             }
         });
+    }
+
+    private static string FormatExceptionMessage(Exception exception)
+    {
+        var baseException = exception.GetBaseException();
+        return string.IsNullOrWhiteSpace(baseException.Message)
+            ? baseException.GetType().Name
+            : baseException.Message;
     }
 
     protected void SetProperty<T>(ref T storage, T value, [CallerMemberName] string? propertyName = null)


### PR DESCRIPTION
### Motivation
- The EventMessenger sample previously swallowed exceptions when dialing peers, making connection failures invisible to users.
- Surface useful feedback in the UI and logs so developers/users can see why peer connects fail.
- Avoid changing library behavior — change is limited to the sample application for better observability.

### Description
- Wrap `ConnectToPeerAsync` call in `MainViewModel.ConnectToPeerAsync` with a `try/catch` to handle any exception from the transport.
- On failure: log a concise message to `Console.Error` and show the same text to the user via the existing toast mechanism (`ShowToastAsync`).
- Add a small helper `FormatExceptionMessage(Exception)` to extract the base exception message (or type name if message is empty) for clearer user-facing text.
- Changes are confined to `samples/EventMessenger/ViewModels/MainViewModel.cs` (no production/library code modified).

### Testing
- No automated tests were run as part of this change (sample-only UI improvement).
- Manual validation: built and committed the sample change locally (no runtime test suite executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69455ee549fc832698ecf47ad8882911)