### PR TITLE
Remove internal transport accessors

### DIFF
--- a/docs/implementation-guide.md
+++ b/docs/implementation-guide.md
@@ -47,13 +47,13 @@ The `NetworkedEventAggregator` subscribes to `IEventTransport.EventReceived`, so
 
 ## 3. Observe the Session Pipeline
 
-`TCPEventTransport` exposes its building blocks via `IEventTransport.PersistentPortListener` and `IEventTransport.PersistentFramePublisher`. Both hold references to the same `SessionManager`, which coordinates:
+`TCPEventTransport` wires a resilient listener and publisher around a shared `SessionManager`, which coordinates:
 
 - Session creation and deduplication based on `SessionKey`.
 - Long-running `ResilientInboundConnection` instances owned by `PersistentPortListener`.
 - `ResilientCompositSessionConnection` objects that persist outbound envelopes and maintain the durable outbox.
 
-If you need visibility into inbound frames—for example, to add metrics or filtering—attach diagnostics inside the transport by observing `IInboundConnectionManager.EventReceived`. `PersistentPortListener` raises this event whenever a `ResilientInboundConnection` produces a domain event; `TCPEventTransport` subscribes to it and forwards the callback through `IEventTransport.EventReceived`, which is what `NetworkedEventAggregator` consumes. Because the same delegate chain controls acknowledgements, completing the handler successfully indicates that the event was processed and allows `PersistentEventPublisher.AcknowledgeEventReceipt` to trim the outbox for that session.
+`PersistentPortListener` raises `IInboundConnectionManager.EventReceived` whenever a `ResilientInboundConnection` produces a domain event; `TCPEventTransport` subscribes to it and forwards the callback through `IEventTransport.EventReceived`, which is what `NetworkedEventAggregator` consumes. Because the same delegate chain controls acknowledgements, completing the handler successfully indicates that the event was processed and allows `PersistentEventPublisher.AcknowledgeEventReceipt` to trim the outbox for that session.
 
 ## 4. Start Listening and Join Peers
 

--- a/src/Yaref92.Events/Abstractions/IEventTransport.cs
+++ b/src/Yaref92.Events/Abstractions/IEventTransport.cs
@@ -28,10 +28,6 @@ public interface IEventTransport
     /// </summary>
     event SessionInboundConnectionDroppedHandler SessionInboundConnectionDropped;
 
-    internal IPersistentPortListener PersistentPortListener { get; }
-
-    internal IPersistentFramePublisher PersistentFramePublisher { get; }
-
     /// <summary>
     /// Publishes an event asynchronously to the transport.
     /// </summary>

--- a/src/Yaref92.Events/Transports/TCPEventTransport.cs
+++ b/src/Yaref92.Events/Transports/TCPEventTransport.cs
@@ -15,11 +15,8 @@ public class TCPEventTransport : IEventTransport, IAsyncDisposable
 #if DEBUG
     internal IEventSerializer SerializerForTesting => _serializer;
     internal IPersistentFramePublisher PublisherForTesting => _publisher;
+    internal IPersistentPortListener ListenerForTesting => _listener;
 #endif
-
-    IPersistentPortListener IEventTransport.PersistentPortListener => _listener;
-
-    IPersistentFramePublisher IEventTransport.PersistentFramePublisher => _publisher;
 
     private event Func<IDomainEvent, Task<bool>>? EventReceived;
 

--- a/tests/Yaref92.Events.IntegrationTests/TCPEventTransportTests.cs
+++ b/tests/Yaref92.Events.IntegrationTests/TCPEventTransportTests.cs
@@ -149,7 +149,7 @@ public class TCPEventTransportTests
             return Task.FromResult(false);
         };
 
-        var inboundA = ((IEventTransport) transportA).PersistentPortListener.ConnectionManager;
+        var inboundA = transportA.ListenerForTesting.ConnectionManager;
         inboundA.AckReceived += (eventId, _) =>
         {
             ackObservedAtA.TrySetResult(eventId);
@@ -161,7 +161,7 @@ public class TCPEventTransportTests
             return Task.CompletedTask;
         };
 
-        var inboundB = ((IEventTransport) transportB).PersistentPortListener.ConnectionManager;
+        var inboundB = transportB.ListenerForTesting.ConnectionManager;
         inboundB.AckReceived += (eventId, _) =>
         {
             ackObservedAtB.TrySetResult(eventId);


### PR DESCRIPTION
### Motivation
- Avoid exposing internal transport building blocks through `IEventTransport` by removing the `PersistentPortListener` and `PersistentFramePublisher` accessors.
- Keep the external transport API surface (`EventReceived`, `SessionInboundConnectionDropped`, and `PublishEventAsync`) unchanged.
- Allow tests and internal code to still access the listener for diagnostics in a safer, transport-local way.
- Update documentation to reflect that the transport wires resilient components internally rather than exposing them via the interface.

### Description
- Removed `internal IPersistentPortListener PersistentPortListener { get; }` and `internal IPersistentFramePublisher PersistentFramePublisher { get; }` from `IEventTransport`.
- Added a testing-only accessor `ListenerForTesting` (internal property under `#if DEBUG`) on `TCPEventTransport` so tests can access the listener connection manager without interface leakage.
- Replaced usages in integration tests to use `transport.ListenerForTesting.ConnectionManager` instead of casting to `IEventTransport` and reading internal members.
- Updated the implementation guide wording to stop referencing the removed interface accessors and describe the transport wiring internally.

### Testing
- No automated tests were executed as part of this change.
- Integration test sources were updated (`tests/Yaref92.Events.IntegrationTests/TCPEventTransportTests.cs`) to use the new `ListenerForTesting` accessor.
- Developers should run `dotnet test Yaref92.Events.sln` locally or in CI to verify unit and integration suites pass after these changes.
- Manual verification was not performed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948ff6dd6b0832688886d920c83ec06)