### PR TITLE
Add gRPC packages and event transport protobuf

### DIFF
--- a/src/Yaref92.Events/Transports/Grpc/event_transport.proto
+++ b/src/Yaref92.Events/Transports/Grpc/event_transport.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+service EventStream {
+  rpc Connect(stream TransportFrame) returns (stream TransportFrame);
+}
+
+message TransportFrame {
+  string event_id = 1;
+  string type_name = 2;
+  string event_json = 3;
+  string sender_id = 4;
+  FrameKind kind = 5;
+}
+
+enum FrameKind {
+  EVENT = 0;
+  ACK = 1;
+}

--- a/src/Yaref92.Events/Yaref92.Events.csproj
+++ b/src/Yaref92.Events/Yaref92.Events.csproj
@@ -26,12 +26,21 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.65.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.65.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.65.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Yaref92.Events.UnitTests" />
     <InternalsVisibleTo Include="Yaref92.Events.IntegrationTests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="Transports/Grpc/event_transport.proto" GrpcServices="Server,Client" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Motivation
- Enable a gRPC-based transport for the events library by adding the required dependencies and a wire-format definition.
- Provide a simple streaming RPC and frame message so clients and server can exchange events and acknowledgements.
- Integrate the proto into the project build so generated server/client code is produced automatically.

### Description
- Added package references `Grpc.AspNetCore`, `Grpc.Net.Client`, and `Grpc.Tools` (with `<PrivateAssets>all</PrivateAssets>`) to `src/Yaref92.Events/Yaref92.Events.csproj`.
- Created `src/Yaref92.Events/Transports/Grpc/event_transport.proto` which defines `service EventStream { rpc Connect(stream TransportFrame) returns (stream TransportFrame); }`, the `TransportFrame` message, and the `FrameKind` enum containing `EVENT` and `ACK`.
- Added `<Protobuf Include="Transports/Grpc/event_transport.proto" GrpcServices="Server,Client" />` to the project so gRPC code generation runs for both server and client.
- Kept the proto intentionally minimal to establish the transport contract without adding behavior.

### Testing
- No automated tests were run after these changes.
- No test failures were observed because no tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694900639c648326aae0452041f8e866)