### PR TITLE
Use GrpcEventTransport in EventMessenger sample

### DIFF
--- a/samples/EventMessenger/MauiProgram.cs
+++ b/samples/EventMessenger/MauiProgram.cs
@@ -20,12 +20,12 @@ public static class MauiProgram
         builder.Services.AddSingleton<MainViewModel>();
         builder.Services.AddSingleton(new MessengerSettings { ListenPort = port });
 
-        builder.Services.AddSingleton(provider => new TCPEventTransport(port));
+        builder.Services.AddSingleton(provider => new GrpcEventTransport(port));
         builder.Services.AddSingleton<EventAggregator>();
         builder.Services.AddSingleton(provider =>
         {
             var localAggregator = provider.GetRequiredService<EventAggregator>();
-            var transport = provider.GetRequiredService<TCPEventTransport>();
+            var transport = provider.GetRequiredService<GrpcEventTransport>();
             var aggregator = new NetworkedEventAggregator(localAggregator, transport, ownsLocalAggregator: false, ownsTransport: false);
             aggregator.RegisterEventType<MessageEvent>();
             return aggregator;

--- a/samples/EventMessenger/ViewModels/MainViewModel.cs
+++ b/samples/EventMessenger/ViewModels/MainViewModel.cs
@@ -15,7 +15,7 @@ namespace EventMessenger.ViewModels;
 public class MainViewModel : INotifyPropertyChanged
 {
     private readonly NetworkedEventAggregator _aggregator;
-    private readonly TCPEventTransport _transport;
+    private readonly GrpcEventTransport _transport;
     private readonly MessengerSettings _settings;
     private bool _isListening;
     private string _peerHost = "localhost";
@@ -23,7 +23,7 @@ public class MainViewModel : INotifyPropertyChanged
     private string _myPort = "5050";
     private string _messageText = string.Empty;
 
-    public MainViewModel(NetworkedEventAggregator aggregator, TCPEventTransport transport, MessengerSettings settings)
+    public MainViewModel(NetworkedEventAggregator aggregator, GrpcEventTransport transport, MessengerSettings settings)
     {
         _aggregator = aggregator;
         _transport = transport;


### PR DESCRIPTION
### Motivation
- Replace the sample app's TCP transport with the gRPC transport to demonstrate `GrpcEventTransport` usage.
- Align the dependency injection registrations and constructor dependencies with the gRPC transport type.
- Preserve existing runtime calls to start listening and connect to peers so behavior remains unchanged.

### Description
- Register `GrpcEventTransport` in `samples/EventMessenger/MauiProgram.cs` instead of `TCPEventTransport` via `builder.Services.AddSingleton(provider => new GrpcEventTransport(port))`.
- Update the `NetworkedEventAggregator` factory to resolve `GrpcEventTransport` rather than `TCPEventTransport`.
- Change `MainViewModel` constructor and private field to depend on `GrpcEventTransport` instead of `TCPEventTransport`.
- No changes were made to calls such as `StartListeningAsync()` and `ConnectToPeerAsync()` on the transport, preserving runtime behavior.

### Testing
- No automated tests were executed as part of this change.
- Local build/compilation was not run by the automated rollout (no test results to report).
- Manual runtime validation was not recorded in the PR metadata.
- Existing behavior regarding listener/connect calls remains intact by design.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949063d25308326836c9b6ac4be5e6a)