### PR TITLE
Use timestamped RC versions in CI

### DIFF
--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -64,17 +64,8 @@ jobs:
 
         if [ "${{ inputs.snapshot }}" = "true" ]; then
           baseVersion="${{ steps.gitversion.outputs.majorMinorPatch }}"
-          rcPrefix="${baseVersion}-rc"
-
-          lastRcNumber=$(git tag --list "${rcPrefix}*" | sed -E "s/^${rcPrefix}[.-]?//" | sed '/^$/d' | sort -V | tail -n 1)
-
-          if [ -z "$lastRcNumber" ]; then
-            nextRcNumber=1
-          else
-            nextRcNumber=$((lastRcNumber + 1))
-          fi
-
-          semVer="${rcPrefix}${nextRcNumber}"
+          rcTimestamp="$(date -u +%Y%m%d%H%M%S)"
+          semVer="${baseVersion}-rc.${rcTimestamp}"
           nugetVersion="$semVer"
           informationalVersion="$semVer"
         fi


### PR DESCRIPTION
### Motivation
- Avoid duplicate-release collisions when creating RC (snapshot) packages by eliminating the incrementing integer scheme that could produce already-used versions.
- Ensure RC snapshot versions are unique and monotonic across runs without relying on repository tag scanning.

### Description
- Replaced the RC tag-scanning and incrementing logic in `.github/workflows/ci-pipeline.yaml` with a UTC timestamp-based suffix using `rcTimestamp=$(date -u +%Y%m%d%H%M%S)`.
- Set `semVer` to ``${baseVersion}-rc.${rcTimestamp}`` and propagated that value to `nugetVersion` and `informationalVersion`.
- Removed the `git tag --list`/`sort`/arithmetic incrementing code path while keeping the rest of the version selection and outputs unchanged.

### Testing
- No automated tests were run because this is a workflow-only change that affects GitHub Actions behavior. 
- Existing CI build and test steps were not executed as part of this PR validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69490d0538988326ad17d83c94b7ec20)