### PR TITLE
Allow RC (snapshot) releases from non-main branches via workflow_dispatch

### DIFF
--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -107,7 +107,7 @@ jobs:
   tagAndRelease:
     needs: [gitVersion, buildAndTest]
     runs-on: ubuntu-latest
-    if: contains(needs.gitVersion.outputs.branchName, 'main')
+    if: contains(needs.gitVersion.outputs.branchName, 'main') || (github.event_name == 'workflow_dispatch' && inputs.snapshot == 'true')
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
### Motivation
- Allow release-candidate (RC) snapshots to be published even when the workflow runs on branches other than `main`.
- Support manual workflow dispatch with the `snapshot` input to trigger tagging and package publication for RCs.
- Avoid blocking snapshot/tag creation behind the `main`-only restriction so maintainers can produce RCs from feature or release branches.

### Description
- Modified the `tagAndRelease` job `if` condition in `.github/workflows/ci-pipeline.yaml` to `contains(needs.gitVersion.outputs.branchName, 'main') || (github.event_name == 'workflow_dispatch' && inputs.snapshot == 'true')`.
- This keeps all existing tagging, pack, and publish steps unchanged while permitting snapshot-triggered runs off `main`.
- No other CI job steps or permissions were altered.

### Testing
- No automated tests were run because this change is workflow-only and does not modify runtime code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69490ff0d78083269585eeced04a7c92)