### PR TITLE
Extract gRPC server hosting into new Yaref92.Events.Server project

### DIFF
--- a/Yaref92.Events.ci.slnf
+++ b/Yaref92.Events.ci.slnf
@@ -2,6 +2,7 @@
   "solution": {
     "path": "Yaref92.Events.sln",
     "projects": [
+      "src/Yaref92.Events.Server/Yaref92.Events.Server.csproj",
       "src/Yaref92.Events.Rx/Yaref92.Events.Rx.csproj",
       "src/Yaref92.Events/Yaref92.Events.csproj",
       "tests/Yaref92.Events.IntegrationTests/Yaref92.Events.IntegrationTests.csproj",

--- a/Yaref92.Events.sln
+++ b/Yaref92.Events.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.10.35004.147
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yaref92.Events", "src\Yaref92.Events\Yaref92.Events.csproj", "{074FC83F-E8AD-45EC-878E-B9E1E7EDA8E4}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yaref92.Events.Server", "src\Yaref92.Events.Server\Yaref92.Events.Server.csproj", "{9E865316-B6FF-4E69-BFF4-EF5487FBA3DE}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{72CB48D8-B0B3-40BD-8F17-B4F4E7C3849B}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
@@ -32,6 +34,10 @@ Global
 		{074FC83F-E8AD-45EC-878E-B9E1E7EDA8E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{074FC83F-E8AD-45EC-878E-B9E1E7EDA8E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{074FC83F-E8AD-45EC-878E-B9E1E7EDA8E4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9E865316-B6FF-4E69-BFF4-EF5487FBA3DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E865316-B6FF-4E69-BFF4-EF5487FBA3DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E865316-B6FF-4E69-BFF4-EF5487FBA3DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9E865316-B6FF-4E69-BFF4-EF5487FBA3DE}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6B8217D5-E58D-4505-A02B-B60F9F2EACA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6B8217D5-E58D-4505-A02B-B60F9F2EACA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6B8217D5-E58D-4505-A02B-B60F9F2EACA5}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/samples/EventMessenger/EventMessenger.csproj
+++ b/samples/EventMessenger/EventMessenger.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Yaref92.Events\Yaref92.Events.csproj" />
+    <ProjectReference Include="..\..\src\Yaref92.Events.Server\Yaref92.Events.Server.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/EventMessenger/MauiProgram.cs
+++ b/samples/EventMessenger/MauiProgram.cs
@@ -2,6 +2,7 @@
 using EventMessenger.ViewModels;
 
 using Yaref92.Events;
+using Yaref92.Events.Server;
 using Yaref92.Events.Sessions;
 using Yaref92.Events.Transports;
 
@@ -22,6 +23,11 @@ public static class MauiProgram
         builder.Services.AddSingleton(new MessengerSettings { ListenPort = port });
 
         builder.Services.AddSingleton(provider => new GrpcEventTransport(port, new SessionManager(port, new ResilientSessionOptions())));
+        builder.Services.AddSingleton(provider =>
+        {
+            var transport = provider.GetRequiredService<GrpcEventTransport>();
+            return new GrpcEventTransportServer(transport);
+        });
         builder.Services.AddSingleton<EventAggregator>();
         builder.Services.AddSingleton(provider =>
         {

--- a/samples/EventMessenger/ViewModels/MainViewModel.cs
+++ b/samples/EventMessenger/ViewModels/MainViewModel.cs
@@ -8,6 +8,7 @@ using EventMessenger.Events;
 
 using Yaref92.Events;
 using Yaref92.Events.Abstractions;
+using Yaref92.Events.Server;
 using Yaref92.Events.Transports;
 
 namespace EventMessenger.ViewModels;
@@ -16,6 +17,7 @@ public class MainViewModel : INotifyPropertyChanged
 {
     private readonly NetworkedEventAggregator _aggregator;
     private readonly GrpcEventTransport _transport;
+    private readonly GrpcEventTransportServer _server;
     private readonly MessengerSettings _settings;
     private bool _isListening;
     private string _peerHost = "localhost";
@@ -23,10 +25,15 @@ public class MainViewModel : INotifyPropertyChanged
     private string _myPort = "5050";
     private string _messageText = string.Empty;
 
-    public MainViewModel(NetworkedEventAggregator aggregator, GrpcEventTransport transport, MessengerSettings settings)
+    public MainViewModel(
+        NetworkedEventAggregator aggregator,
+        GrpcEventTransport transport,
+        GrpcEventTransportServer server,
+        MessengerSettings settings)
     {
         _aggregator = aggregator;
         _transport = transport;
+        _server = server;
         _settings = settings;
         Messages = new ObservableCollection<string>();
         HostHint = ResolveLocalHost();
@@ -77,7 +84,7 @@ public class MainViewModel : INotifyPropertyChanged
             MyPort = _settings.ListenPort.ToString(CultureInfo.InvariantCulture);
         }
 
-        await _transport.StartListeningAsync();
+        await _server.StartListeningAsync();
         _isListening = true;
         await ShowToastAsync($"Listening on {HostHint}:{MyPort}");
     }

--- a/src/Yaref92.Events.Server/EventStreamService.cs
+++ b/src/Yaref92.Events.Server/EventStreamService.cs
@@ -1,0 +1,32 @@
+using Grpc.Core;
+
+using Yaref92.Events.Transports;
+
+namespace Yaref92.Events.Server;
+
+internal sealed class EventStreamService : global::EventStream.EventStreamBase
+{
+    private readonly GrpcEventTransport _transport;
+
+    public EventStreamService(GrpcEventTransport transport)
+    {
+        _transport = transport;
+    }
+
+    public override async Task Connect(
+        IAsyncStreamReader<TransportFrame> requestStream,
+        IServerStreamWriter<TransportFrame> responseStream,
+        ServerCallContext context)
+    {
+        var registration = _transport.RegisterStream(responseStream);
+        try
+        {
+            await _transport.ProcessIncomingStreamAsync(requestStream, registration, context.CancellationToken)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            _transport.UnregisterStream(registration);
+        }
+    }
+}

--- a/src/Yaref92.Events.Server/GrpcEventTransportServer.cs
+++ b/src/Yaref92.Events.Server/GrpcEventTransportServer.cs
@@ -1,0 +1,81 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Yaref92.Events.Transports;
+
+namespace Yaref92.Events.Server;
+
+public sealed class GrpcEventTransportServer : IAsyncDisposable
+{
+    private readonly GrpcEventTransport _transport;
+    private IHost? _host;
+    private Task? _disposeTask;
+    private int _disposeState;
+
+    public GrpcEventTransportServer(GrpcEventTransport transport)
+    {
+        _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+    }
+
+    public Task StartListeningAsync(CancellationToken cancellationToken = default)
+    {
+        if (_host is not null)
+        {
+            return Task.CompletedTask;
+        }
+
+        _host = Host.CreateDefaultBuilder()
+            .ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.ConfigureKestrel(options =>
+                {
+                    options.ListenAnyIP(_transport.ListenPort, listenOptions =>
+                    {
+                        listenOptions.Protocols = HttpProtocols.Http2;
+                    });
+                });
+                webBuilder.ConfigureServices(services =>
+                {
+                    services.AddGrpc();
+                    services.AddSingleton(_transport);
+                    services.AddSingleton<EventStreamService>();
+                });
+                webBuilder.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapGrpcService<EventStreamService>();
+                    });
+                });
+            })
+            .Build();
+
+        return _host.StartAsync(cancellationToken);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        if (Interlocked.CompareExchange(ref _disposeState, 1, 0) == 0)
+        {
+            _disposeTask = DisposeAsyncCore();
+        }
+
+        return _disposeTask is null ? ValueTask.CompletedTask : new ValueTask(_disposeTask);
+    }
+
+    private async Task DisposeAsyncCore()
+    {
+        if (_host is null)
+        {
+            return;
+        }
+
+        await _host.StopAsync().ConfigureAwait(false);
+        _host.Dispose();
+        _host = null;
+    }
+}

--- a/src/Yaref92.Events.Server/Yaref92.Events.Server.csproj
+++ b/src/Yaref92.Events.Server/Yaref92.Events.Server.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Authors>yaref92</Authors>
+    <Description>Server hosting for Yaref92.Events gRPC transport.</Description>
+    <RepositoryUrl>https://github.com/yaron-E92/events</RepositoryUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Yaref92.Events\Yaref92.Events.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.65.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Yaref92.Events/Yaref92.Events.csproj
+++ b/src/Yaref92.Events/Yaref92.Events.csproj
@@ -26,7 +26,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />
-    <PackageReference Include="Grpc.AspNetCore" Version="2.65.0" />
     <PackageReference Include="Grpc.Net.Client" Version="2.65.0" />
     <PackageReference Include="Grpc.Tools" Version="2.65.0">
       <PrivateAssets>all</PrivateAssets>
@@ -36,6 +35,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Yaref92.Events.UnitTests" />
     <InternalsVisibleTo Include="Yaref92.Events.IntegrationTests" />
+    <InternalsVisibleTo Include="Yaref92.Events.Server" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2"/>
   </ItemGroup>
 


### PR DESCRIPTION
### Motivation
- Decouple server-hosting concerns (ASP.NET Core and Kestrel) from the core transport to keep the core library focused on shared transport logic.
- Remove the `Grpc.AspNetCore` dependency from the core `Yaref92.Events` package so it can be reused in non-hosting contexts.
- Provide a small, explicit hosting entry point that composes existing transport internals to run the gRPC server.

### Description
- Created a new project `src/Yaref92.Events.Server` with `GrpcEventTransportServer` that owns Kestrel/ASP.NET Core wiring and exposes `StartListeningAsync`.
- Removed ASP.NET Core hosting code and `Grpc.AspNetCore` package reference from `GrpcEventTransport`, added `ListenPort` property, and made stream lifecycle members (`RegisterStream`, `UnregisterStream`, `ProcessIncomingStreamAsync`, and `StreamRegistration`) internal so the server project can reuse them.
- Added `InternalsVisibleTo` for the server project, updated solution and CI solution files, and updated the sample `EventMessenger` to register and start `GrpcEventTransportServer` via DI.
- Added `Protobuf`/gRPC client tooling remains in the core for client usage while server hosting is now isolated to the new project.

### Testing
- No automated tests were executed as part of this change set (no test command was run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949765761e88326b704e6d9b8dc9a6f)