### PR TITLE
Platform-specific gRPC server hosts (Android / non-Android)

### DIFF
--- a/src/Yaref92.Events.Server/GrpcEventTransportServer.cs
+++ b/src/Yaref92.Events.Server/GrpcEventTransportServer.cs
@@ -1,81 +1,32 @@
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Server.Kestrel.Core;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-
 using Yaref92.Events.Transports;
 
 namespace Yaref92.Events.Server;
 
-public sealed class GrpcEventTransportServer : IAsyncDisposable
+public sealed partial class GrpcEventTransportServer : IAsyncDisposable
 {
     private readonly GrpcEventTransport _transport;
-    private IHost? _host;
-    private Task? _disposeTask;
-    private int _disposeState;
+    private readonly IGrpcEventTransportServerHost _host;
 
     public GrpcEventTransportServer(GrpcEventTransport transport)
     {
         _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+        _host = CreateServerHost(_transport);
     }
 
     public Task StartListeningAsync(CancellationToken cancellationToken = default)
     {
-        if (_host is not null)
-        {
-            return Task.CompletedTask;
-        }
-
-        _host = Host.CreateDefaultBuilder()
-            .ConfigureWebHostDefaults(webBuilder =>
-            {
-                webBuilder.ConfigureKestrel(options =>
-                {
-                    options.ListenAnyIP(_transport.ListenPort, listenOptions =>
-                    {
-                        listenOptions.Protocols = HttpProtocols.Http2;
-                    });
-                });
-                webBuilder.ConfigureServices(services =>
-                {
-                    services.AddGrpc();
-                    services.AddSingleton(_transport);
-                    services.AddSingleton<EventStreamService>();
-                });
-                webBuilder.Configure(app =>
-                {
-                    app.UseRouting();
-                    app.UseEndpoints(endpoints =>
-                    {
-                        endpoints.MapGrpcService<EventStreamService>();
-                    });
-                });
-            })
-            .Build();
-
-        return _host.StartAsync(cancellationToken);
+        return _host.StartListeningAsync(cancellationToken);
     }
 
     public ValueTask DisposeAsync()
     {
-        if (Interlocked.CompareExchange(ref _disposeState, 1, 0) == 0)
-        {
-            _disposeTask = DisposeAsyncCore();
-        }
-
-        return _disposeTask is null ? ValueTask.CompletedTask : new ValueTask(_disposeTask);
+        return _host.DisposeAsync();
     }
 
-    private async Task DisposeAsyncCore()
-    {
-        if (_host is null)
-        {
-            return;
-        }
+    private static partial IGrpcEventTransportServerHost CreateServerHost(GrpcEventTransport transport);
+}
 
-        await _host.StopAsync().ConfigureAwait(false);
-        _host.Dispose();
-        _host = null;
-    }
+internal interface IGrpcEventTransportServerHost : IAsyncDisposable
+{
+    Task StartListeningAsync(CancellationToken cancellationToken);
 }

--- a/src/Yaref92.Events.Server/GrpcEventTransportServerHost.Android.cs
+++ b/src/Yaref92.Events.Server/GrpcEventTransportServerHost.Android.cs
@@ -1,0 +1,66 @@
+#if ANDROID
+using Grpc.Core;
+
+using Yaref92.Events.Transports;
+
+namespace Yaref92.Events.Server;
+
+public sealed partial class GrpcEventTransportServer
+{
+    private static partial IGrpcEventTransportServerHost CreateServerHost(GrpcEventTransport transport)
+    {
+        return new GrpcCoreEventTransportServerHost(transport);
+    }
+}
+
+internal sealed class GrpcCoreEventTransportServerHost : IGrpcEventTransportServerHost
+{
+    private readonly GrpcEventTransport _transport;
+    private Server? _server;
+    private Task? _disposeTask;
+    private int _disposeState;
+
+    public GrpcCoreEventTransportServerHost(GrpcEventTransport transport)
+    {
+        _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+    }
+
+    public Task StartListeningAsync(CancellationToken cancellationToken)
+    {
+        if (_server is not null)
+        {
+            return Task.CompletedTask;
+        }
+
+        _server = new Server
+        {
+            Services = { global::EventStream.BindService(new EventStreamService(_transport)) },
+            Ports = { new ServerPort("0.0.0.0", _transport.ListenPort, ServerCredentials.Insecure) },
+        };
+
+        _server.Start();
+        return Task.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        if (Interlocked.CompareExchange(ref _disposeState, 1, 0) == 0)
+        {
+            _disposeTask = DisposeAsyncCore();
+        }
+
+        return _disposeTask is null ? ValueTask.CompletedTask : new ValueTask(_disposeTask);
+    }
+
+    private async Task DisposeAsyncCore()
+    {
+        if (_server is null)
+        {
+            return;
+        }
+
+        await _server.ShutdownAsync().ConfigureAwait(false);
+        _server = null;
+    }
+}
+#endif

--- a/src/Yaref92.Events.Server/GrpcEventTransportServerHost.Default.cs
+++ b/src/Yaref92.Events.Server/GrpcEventTransportServerHost.Default.cs
@@ -1,0 +1,91 @@
+#if !ANDROID
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Yaref92.Events.Transports;
+
+namespace Yaref92.Events.Server;
+
+public sealed partial class GrpcEventTransportServer
+{
+    private static partial IGrpcEventTransportServerHost CreateServerHost(GrpcEventTransport transport)
+    {
+        return new KestrelGrpcEventTransportServerHost(transport);
+    }
+}
+
+internal sealed class KestrelGrpcEventTransportServerHost : IGrpcEventTransportServerHost
+{
+    private readonly GrpcEventTransport _transport;
+    private IHost? _host;
+    private Task? _disposeTask;
+    private int _disposeState;
+
+    public KestrelGrpcEventTransportServerHost(GrpcEventTransport transport)
+    {
+        _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+    }
+
+    public Task StartListeningAsync(CancellationToken cancellationToken)
+    {
+        if (_host is not null)
+        {
+            return Task.CompletedTask;
+        }
+
+        _host = Host.CreateDefaultBuilder()
+            .ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.ConfigureKestrel(options =>
+                {
+                    options.ListenAnyIP(_transport.ListenPort, listenOptions =>
+                    {
+                        listenOptions.Protocols = HttpProtocols.Http2;
+                    });
+                });
+                webBuilder.ConfigureServices(services =>
+                {
+                    services.AddGrpc();
+                    services.AddSingleton(_transport);
+                    services.AddSingleton<EventStreamService>();
+                });
+                webBuilder.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapGrpcService<EventStreamService>();
+                    });
+                });
+            })
+            .Build();
+
+        return _host.StartAsync(cancellationToken);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        if (Interlocked.CompareExchange(ref _disposeState, 1, 0) == 0)
+        {
+            _disposeTask = DisposeAsyncCore();
+        }
+
+        return _disposeTask is null ? ValueTask.CompletedTask : new ValueTask(_disposeTask);
+    }
+
+    private async Task DisposeAsyncCore()
+    {
+        if (_host is null)
+        {
+            return;
+        }
+
+        await _host.StopAsync().ConfigureAwait(false);
+        _host.Dispose();
+        _host = null;
+    }
+}
+#endif

--- a/src/Yaref92.Events.Server/Yaref92.Events.Server.csproj
+++ b/src/Yaref92.Events.Server/Yaref92.Events.Server.csproj
@@ -13,9 +13,13 @@
     <ProjectReference Include="..\Yaref92.Events\Yaref92.Events.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != 'Android'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.65.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'Android'">
+    <PackageReference Include="Grpc.Core" Version="2.65.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Motivation
- Remove the dependency on `Microsoft.AspNetCore.App` for Android builds by providing an alternative host implementation.
- Keep the public API surface small by exposing a single `StartListeningAsync` entry point regardless of platform.
- Move Kestrel/ASP.NET Core hosting code out of the transport class so platform concerns are isolated.

### Description
- Refactored `GrpcEventTransportServer` into a partial class that delegates hosting to a platform host via a `CreateServerHost` partial factory and the `IGrpcEventTransportServerHost` interface.
- Added `GrpcEventTransportServerHost.Default.cs` which implements `KestrelGrpcEventTransportServerHost` using ASP.NET Core and Kestrel for non-Android targets.
- Added `GrpcEventTransportServerHost.Android.cs` which implements `GrpcCoreEventTransportServerHost` using `Grpc.Core` for Android targets and binds `EventStreamService` directly.
- Updated `Yaref92.Events.Server.csproj` to conditionally reference `Microsoft.AspNetCore.App` and `Grpc.AspNetCore` for non-Android builds and `Grpc.Core` for Android builds.

### Testing
- No automated tests were run against these changes.
- No build/test commands were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949797e61c88326af416b5c7d913c9d)