### PR TITLE
Multi-target server: add net8.0-android TFM and ANDROID define

### DIFF
--- a/src/Yaref92.Events.Server/Yaref92.Events.Server.csproj
+++ b/src/Yaref92.Events.Server/Yaref92.Events.Server.csproj
@@ -1,12 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net8.0-android</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Authors>yaref92</Authors>
     <Description>Server hosting for Yaref92.Events gRPC transport.</Description>
     <RepositoryUrl>https://github.com/yaron-E92/events</RepositoryUrl>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
+    <DefineConstants>$(DefineConstants);ANDROID</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation
- Enable building the server project for Android so platform-specific host code can be included when targeting Android.
- Ensure `#if ANDROID` guarded sources are compiled under the Android TFM.
- Preserve existing conditional package and framework references between Android and non-Android targets.

### Description
- Replace `TargetFramework` with `TargetFrameworks` and add `net8.0;net8.0-android` to `Yaref92.Events.Server.csproj`.
- Add a `PropertyGroup` conditioned on `$(TargetFramework)` == `net8.0-android` that appends `ANDROID` to `DefineConstants` so `#if ANDROID` sources are enabled.
- Keep existing `ItemGroup` conditions that use `$(TargetFrameworkIdentifier)` to select `Microsoft.AspNetCore.App`/`Grpc.AspNetCore` for non-Android and `Grpc.Core` for Android.
- This change enables `GrpcEventTransportServerHost.Android.cs` (which contains `#if ANDROID`) to be included when building the `net8.0-android` target.

### Testing
- No automated tests were executed as part of this change.
- Manual build/CI validation was not performed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69497e718e5c83268f821662372edce0)