### PR TITLE
Prefer active IPv4 when resolving host hint

### DIFF
--- a/samples/EventMessenger/ViewModels/MainViewModel.cs
+++ b/samples/EventMessenger/ViewModels/MainViewModel.cs
@@ -125,14 +125,14 @@ public class MainViewModel : INotifyPropertyChanged
 
     private static string ResolveLocalHost()
     {
+        var localIp = GetActiveIpv4Address();
+        if (localIp is not null)
+        {
+            return localIp;
+        }
+
         try
         {
-            var localIp = GetActiveIpv4Address();
-            if (localIp is not null)
-            {
-                return localIp;
-            }
-
             string hostName = Dns.GetHostName();
             var entry = Dns.GetHostEntry(hostName);
             var address = entry.AddressList.FirstOrDefault(a => a.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork);
@@ -146,28 +146,35 @@ public class MainViewModel : INotifyPropertyChanged
 
     private static string? GetActiveIpv4Address()
     {
-        var activeInterfaces = NetworkInterface.GetAllNetworkInterfaces()
-            .Where(networkInterface =>
-                networkInterface.OperationalStatus == OperationalStatus.Up
-                && networkInterface.NetworkInterfaceType != NetworkInterfaceType.Loopback
-                && networkInterface.NetworkInterfaceType != NetworkInterfaceType.Tunnel)
-            .ToArray();
+        try
+        {
+            var activeInterfaces = NetworkInterface.GetAllNetworkInterfaces()
+                .Where(networkInterface =>
+                    networkInterface.OperationalStatus == OperationalStatus.Up
+                    && networkInterface.NetworkInterfaceType != NetworkInterfaceType.Loopback
+                    && networkInterface.NetworkInterfaceType != NetworkInterfaceType.Tunnel)
+                .ToArray();
 
-        var address = activeInterfaces
-            .Where(networkInterface => networkInterface.GetIPProperties().GatewayAddresses.Any(gateway =>
-                gateway.Address.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork
-                && !IPAddress.IsLoopback(gateway.Address)
-                && gateway.Address != IPAddress.Any
-                && gateway.Address != IPAddress.None))
-            .SelectMany(networkInterface => networkInterface.GetIPProperties().UnicastAddresses)
-            .Select(addressInfo => addressInfo.Address)
-            .FirstOrDefault(IsRoutableIpv4Address)
-            ?? activeInterfaces
+            var address = activeInterfaces
+                .Where(networkInterface => networkInterface.GetIPProperties().GatewayAddresses.Any(gateway =>
+                    gateway.Address.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork
+                    && !IPAddress.IsLoopback(gateway.Address)
+                    && gateway.Address != IPAddress.Any
+                    && gateway.Address != IPAddress.None))
                 .SelectMany(networkInterface => networkInterface.GetIPProperties().UnicastAddresses)
                 .Select(addressInfo => addressInfo.Address)
-                .FirstOrDefault(IsRoutableIpv4Address);
+                .FirstOrDefault(IsRoutableIpv4Address)
+                ?? activeInterfaces
+                    .SelectMany(networkInterface => networkInterface.GetIPProperties().UnicastAddresses)
+                    .Select(addressInfo => addressInfo.Address)
+                    .FirstOrDefault(IsRoutableIpv4Address);
 
-        return address?.ToString();
+            return address?.ToString();
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private static bool IsRoutableIpv4Address(IPAddress address)

--- a/samples/EventMessenger/ViewModels/MainViewModel.cs
+++ b/samples/EventMessenger/ViewModels/MainViewModel.cs
@@ -135,8 +135,13 @@ public class MainViewModel : INotifyPropertyChanged
         {
             string hostName = Dns.GetHostName();
             var entry = Dns.GetHostEntry(hostName);
-            var address = entry.AddressList.FirstOrDefault(a => a.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork);
-            return address?.ToString() ?? hostName;
+            var address = entry.AddressList.FirstOrDefault(IsRoutableIpv4Address);
+            if (address is not null)
+            {
+                return address.ToString();
+            }
+
+            return string.Equals(hostName, "localhost", StringComparison.OrdinalIgnoreCase) ? "localhost" : hostName;
         }
         catch
         {

--- a/samples/EventMessenger/ViewModels/MainViewModel.cs
+++ b/samples/EventMessenger/ViewModels/MainViewModel.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Globalization;
 using System.Net;
+using System.Net.NetworkInformation;
 using System.Runtime.CompilerServices;
 
 using EventMessenger.Events;
@@ -126,6 +127,12 @@ public class MainViewModel : INotifyPropertyChanged
     {
         try
         {
+            var localIp = GetActiveIpv4Address();
+            if (localIp is not null)
+            {
+                return localIp;
+            }
+
             string hostName = Dns.GetHostName();
             var entry = Dns.GetHostEntry(hostName);
             var address = entry.AddressList.FirstOrDefault(a => a.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork);
@@ -135,6 +142,18 @@ public class MainViewModel : INotifyPropertyChanged
         {
             return "localhost";
         }
+    }
+
+    private static string? GetActiveIpv4Address()
+    {
+        return NetworkInterface.GetAllNetworkInterfaces()
+            .Where(networkInterface => networkInterface.OperationalStatus == OperationalStatus.Up)
+            .SelectMany(networkInterface => networkInterface.GetIPProperties().UnicastAddresses)
+            .Select(addressInfo => addressInfo.Address)
+            .FirstOrDefault(address =>
+                address.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork
+                && !IPAddress.IsLoopback(address))
+            ?.ToString();
     }
 
     private static Task ShowToastAsync(string message)

--- a/samples/EventMessenger/ViewModels/MainViewModel.cs
+++ b/samples/EventMessenger/ViewModels/MainViewModel.cs
@@ -146,14 +146,44 @@ public class MainViewModel : INotifyPropertyChanged
 
     private static string? GetActiveIpv4Address()
     {
-        return NetworkInterface.GetAllNetworkInterfaces()
-            .Where(networkInterface => networkInterface.OperationalStatus == OperationalStatus.Up)
+        var activeInterfaces = NetworkInterface.GetAllNetworkInterfaces()
+            .Where(networkInterface =>
+                networkInterface.OperationalStatus == OperationalStatus.Up
+                && networkInterface.NetworkInterfaceType != NetworkInterfaceType.Loopback
+                && networkInterface.NetworkInterfaceType != NetworkInterfaceType.Tunnel)
+            .ToArray();
+
+        var address = activeInterfaces
+            .Where(networkInterface => networkInterface.GetIPProperties().GatewayAddresses.Any(gateway =>
+                gateway.Address.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork
+                && !IPAddress.IsLoopback(gateway.Address)
+                && gateway.Address != IPAddress.Any
+                && gateway.Address != IPAddress.None))
             .SelectMany(networkInterface => networkInterface.GetIPProperties().UnicastAddresses)
             .Select(addressInfo => addressInfo.Address)
-            .FirstOrDefault(address =>
-                address.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork
-                && !IPAddress.IsLoopback(address))
-            ?.ToString();
+            .FirstOrDefault(IsRoutableIpv4Address)
+            ?? activeInterfaces
+                .SelectMany(networkInterface => networkInterface.GetIPProperties().UnicastAddresses)
+                .Select(addressInfo => addressInfo.Address)
+                .FirstOrDefault(IsRoutableIpv4Address);
+
+        return address?.ToString();
+    }
+
+    private static bool IsRoutableIpv4Address(IPAddress address)
+    {
+        if (address.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
+        {
+            return false;
+        }
+
+        if (IPAddress.IsLoopback(address) || address == IPAddress.Any || address == IPAddress.None)
+        {
+            return false;
+        }
+
+        var bytes = address.GetAddressBytes();
+        return bytes is [169, 254, ..] ? false : true;
     }
 
     private static Task ShowToastAsync(string message)


### PR DESCRIPTION
### Motivation
- Ensure the UI `HostHint` shows a usable non-loopback IPv4 address when the machine has active network interfaces.
- Prefer an address that peers can actually reach instead of returning the loopback or an ambiguous hostname.
- Preserve existing fallback behavior to `Dns.GetHostEntry` and ultimately to `"localhost"` when no suitable address is found.

### Description
- Added `using System.Net.NetworkInformation` and a new helper `GetActiveIpv4Address()` that enumerates `NetworkInterface.GetAllNetworkInterfaces()` and filters for `OperationalStatus.Up`.
- `GetActiveIpv4Address()` selects the first `UnicastIPAddressInformation` with `AddressFamily.InterNetwork` that is not `IPAddress.Loopback` and returns its string representation.
- Updated `ResolveLocalHost()` to call `GetActiveIpv4Address()` and return that IP when present, otherwise fall back to the existing `Dns.GetHostEntry` logic or `"localhost"` on error.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952961f8e788326b41657ba53e01342)