### PR TITLE
Add Android device identity to EventMessenger host hints

### DIFF
--- a/samples/EventMessenger/Platforms/Android/DeviceIdentity.cs
+++ b/samples/EventMessenger/Platforms/Android/DeviceIdentity.cs
@@ -1,0 +1,20 @@
+using Microsoft.Maui.Storage;
+
+namespace EventMessenger.Platforms.Android;
+
+internal static class DeviceIdentity
+{
+    private const string PreferenceKey = "EventMessenger.DeviceId";
+
+    internal static string GetDeviceId()
+    {
+        var deviceId = Preferences.Get(PreferenceKey, string.Empty);
+        if (string.IsNullOrWhiteSpace(deviceId))
+        {
+            deviceId = Guid.NewGuid().ToString("N");
+            Preferences.Set(PreferenceKey, deviceId);
+        }
+
+        return deviceId;
+    }
+}

--- a/samples/EventMessenger/ViewModels/MainViewModel.cs
+++ b/samples/EventMessenger/ViewModels/MainViewModel.cs
@@ -5,6 +5,9 @@ using System.Net;
 using System.Runtime.CompilerServices;
 
 using EventMessenger.Events;
+#if ANDROID
+using EventMessenger.Platforms.Android;
+#endif
 
 using Yaref92.Events;
 using Yaref92.Events.Abstractions;
@@ -29,7 +32,7 @@ public class MainViewModel : INotifyPropertyChanged
         _transport = transport;
         _settings = settings;
         Messages = new ObservableCollection<string>();
-        HostHint = ResolveLocalHost();
+        HostHint = ResolveHostHint();
 
         _aggregator.SubscribeToEventType(new AsyncMessageEventHandler(this));
         _myPort = _settings.ListenPort.ToString(CultureInfo.InvariantCulture);
@@ -135,6 +138,22 @@ public class MainViewModel : INotifyPropertyChanged
         {
             return "localhost";
         }
+    }
+
+    private static string ResolveHostHint()
+    {
+#if ANDROID
+        var deviceId = DeviceIdentity.GetDeviceId();
+        var localHost = ResolveLocalHost();
+        if (!string.Equals(localHost, "localhost", StringComparison.OrdinalIgnoreCase))
+        {
+            return $"{deviceId}@{localHost}";
+        }
+
+        return deviceId;
+#else
+        return ResolveLocalHost();
+#endif
     }
 
     private static Task ShowToastAsync(string message)


### PR DESCRIPTION
### Motivation
- Android devices need a stable, unique identifier for message sender identity because `localhost` or ephemeral host/IPs are not useful for distinguishing devices.
- Show the device identity in the local connection summary so users can see a meaningful sender value instead of `localhost`.
- Preserve existing behavior for non-Android platforms so host/IP resolution remains unchanged.

### Description
- Add `samples/EventMessenger/Platforms/Android/DeviceIdentity.cs` which persists a stable GUID in app `Preferences` via `DeviceIdentity.GetDeviceId()`.
- Replace `HostHint = ResolveLocalHost();` with `HostHint = ResolveHostHint();` and add a new `ResolveHostHint()` method that uses `DeviceIdentity.GetDeviceId()` on Android and falls back to `ResolveLocalHost()` on other platforms.
- When a LAN address is available on Android, `ResolveHostHint()` returns a combined value of `{deviceId}@{localIp}` for readability; otherwise it returns only the device ID.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952ae18370c8326a0b47e17e5f41e69)