### PR TITLE
Add DataChannelEnvelope protobuf and encode/decode for gRPC DataChannel

### DIFF
--- a/src/Yaref92.Events.Transport.Grpc/DataChannelProtocol.cs
+++ b/src/Yaref92.Events.Transport.Grpc/DataChannelProtocol.cs
@@ -1,0 +1,31 @@
+using Google.Protobuf;
+
+namespace Yaref92.Events.Transport.Grpc;
+
+internal static class DataChannelProtocol
+{
+    public static byte[] Encode(DataChannelEnvelope envelope)
+    {
+        ArgumentNullException.ThrowIfNull(envelope);
+        return envelope.ToByteArray();
+    }
+
+    public static bool TryDecode(ReadOnlyMemory<byte> payload, out DataChannelEnvelope? envelope)
+    {
+        envelope = null;
+        if (payload.IsEmpty)
+        {
+            return false;
+        }
+
+        try
+        {
+            envelope = DataChannelEnvelope.Parser.ParseFrom(payload.Span);
+            return true;
+        }
+        catch (InvalidProtocolBufferException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Yaref92.Events.Transport.Grpc/Platforms/GrpcEventTransport.android.cs
+++ b/src/Yaref92.Events.Transport.Grpc/Platforms/GrpcEventTransport.android.cs
@@ -275,15 +275,12 @@ public sealed partial class GrpcEventTransport
                     return;
                 }
 
-                TransportFrame frame;
-                try
-                {
-                    frame = TransportFrame.Parser.ParseFrom(data);
-                }
-                catch (InvalidProtocolBufferException)
+                if (!DataChannelProtocol.TryDecode(data, out var envelope))
                 {
                     return;
                 }
+
+                TransportFrame frame = EnvelopeToFrame(envelope);
 
                 await _transport.HandleIncomingFrameAsync(frame, _registration).ConfigureAwait(false);
             };
@@ -332,9 +329,32 @@ public sealed partial class GrpcEventTransport
 
         public Task WriteAsync(TransportFrame message)
         {
-            byte[] payload = message.ToByteArray();
+            DataChannelEnvelope envelope = FrameToEnvelope(message);
+            byte[] payload = DataChannelProtocol.Encode(envelope);
             _channel.send(payload);
             return Task.CompletedTask;
+        }
+    }
+
+    private static DataChannelEnvelope FrameToEnvelope(TransportFrame frame)
+    {
+        return new DataChannelEnvelope
+        {
+            Type = "transport_frame",
+            CorrelationId = frame.EventId ?? string.Empty,
+            Payload = frame.ToByteString(),
+        };
+    }
+
+    private static TransportFrame EnvelopeToFrame(DataChannelEnvelope envelope)
+    {
+        try
+        {
+            return TransportFrame.Parser.ParseFrom(envelope.Payload);
+        }
+        catch (InvalidProtocolBufferException)
+        {
+            return new TransportFrame();
         }
     }
 

--- a/src/Yaref92.Events.Transport.Grpc/Protos/data_channel.proto
+++ b/src/Yaref92.Events.Transport.Grpc/Protos/data_channel.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+message DataChannelEnvelope {
+  string type = 1;
+  string correlation_id = 2;
+  bytes payload = 3;
+}

--- a/src/Yaref92.Events.Transport.Grpc/Yaref92.Events.Transport.Grpc.csproj
+++ b/src/Yaref92.Events.Transport.Grpc/Yaref92.Events.Transport.Grpc.csproj
@@ -44,5 +44,6 @@
 
   <ItemGroup>
     <Protobuf Include="Protos/event_transport.proto" GrpcServices="Server,Client" />
+    <Protobuf Include="Protos/data_channel.proto" />
   </ItemGroup>
 </Project>

--- a/tests/Yaref92.Events.UnitTests/Transports/DataChannelProtocolTests.cs
+++ b/tests/Yaref92.Events.UnitTests/Transports/DataChannelProtocolTests.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+using Google.Protobuf;
+using Yaref92.Events.Transport.Grpc;
+
+namespace Yaref92.Events.UnitTests.Transports;
+
+[TestFixture]
+public class DataChannelProtocolTests
+{
+    [Test]
+    public void EncodeDecode_RoundTripsEnvelope()
+    {
+        var envelope = new DataChannelEnvelope
+        {
+            Type = "event",
+            CorrelationId = Guid.NewGuid().ToString("D"),
+            Payload = ByteString.CopyFromUtf8("payload"),
+        };
+
+        byte[] payload = DataChannelProtocol.Encode(envelope);
+
+        DataChannelProtocol.TryDecode(payload, out var decoded).Should().BeTrue();
+        decoded.Should().NotBeNull();
+        decoded!.Type.Should().Be(envelope.Type);
+        decoded.CorrelationId.Should().Be(envelope.CorrelationId);
+        decoded.Payload.Should().Be(envelope.Payload);
+    }
+
+    [Test]
+    public void TryDecode_ReturnsFalse_ForInvalidPayload()
+    {
+        byte[] payload = { 0xFF };
+
+        DataChannelProtocol.TryDecode(payload, out var decoded).Should().BeFalse();
+        decoded.Should().BeNull();
+    }
+}

--- a/tests/Yaref92.Events.UnitTests/Yaref92.Events.UnitTests.csproj
+++ b/tests/Yaref92.Events.UnitTests/Yaref92.Events.UnitTests.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Yaref92.Events.Transport.Tcp\Yaref92.Events.Transport.Tcp.csproj" />
+    <ProjectReference Include="..\..\src\Yaref92.Events.Transport.Grpc\Yaref92.Events.Transport.Grpc.csproj" />
     <ProjectReference Include="..\..\src\Yaref92.Events\Yaref92.Events.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
### Motivation

- Introduce a small protocol envelope for WebRTC data channel payloads so DataChannel messages can carry a `type`, `correlationId`, and binary `payload` separately from existing gRPC `TransportFrame` semantics.
- Keep existing gRPC `TransportFrame` unchanged while enabling the Android WebRTC data channel path to use the new envelope format.
- Provide safe encode/decode helpers for the envelope to centralize parsing and error handling.
- Add unit tests to validate round-trip encoding/decoding behavior.

### Description

- Added `Protos/data_channel.proto` defining `DataChannelEnvelope` with `type`, `correlation_id`, and `payload` fields and included it in the gRPC project via the project file (`.csproj`).
- Implemented `DataChannelProtocol` helper with `Encode` and `TryDecode` methods to serialize/deserialize `DataChannelEnvelope` using protobuf.
- Updated `GrpcEventTransport` Android platform file to wrap outgoing `TransportFrame` messages in a `DataChannelEnvelope` with `FrameToEnvelope`, and to unwrap incoming envelopes via `EnvelopeToFrame` before passing to existing handlers, leaving `TransportFrame` itself unchanged.
- Added unit tests `DataChannelProtocolTests` and wired the tests project to reference the gRPC transport project so the new tests compile.

### Testing

- Added `DataChannelProtocolTests` which verifies encode/decode round-trip and invalid payload handling using `DataChannelProtocol`.
- No automated test suite was executed as part of this change; tests were added but not run in this rollout.
- Compilation changes include adding the proto to the gRPC project and referencing the gRPC project from the unit test project to enable test compilation.
- No existing behavior of `TransportFrame` serialization over gRPC streams was modified; only the WebRTC data channel path now uses the envelope for payloads.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953ef7a466483268d62b0f99d4d2d4b)