### PR TITLE
Refactor WebRTC signaling into shared helper and add IDataChannelSession

### DIFF
--- a/src/Yaref92.Events.Transport.Grpc/IDataChannelSession.cs
+++ b/src/Yaref92.Events.Transport.Grpc/IDataChannelSession.cs
@@ -1,0 +1,14 @@
+using SIPSorcery.Net;
+
+namespace Yaref92.Events.Transport.Grpc;
+
+internal interface IDataChannelSession : IAsyncDisposable
+{
+    Guid Id { get; }
+
+    Task<bool> ConnectAsync(SignalMessage? offer, TimeSpan? timeout, CancellationToken cancellationToken);
+
+    Task SendAsync(SignalMessage message, CancellationToken cancellationToken = default);
+
+    void HookInboundFrames(RTCDataChannel channel);
+}

--- a/src/Yaref92.Events.Transport.Grpc/Platforms/GrpcEventTransport.android.cs
+++ b/src/Yaref92.Events.Transport.Grpc/Platforms/GrpcEventTransport.android.cs
@@ -62,7 +62,7 @@ public sealed partial class GrpcEventTransport
             SignalMessage? message;
             try
             {
-                message = await ReadSignalMessageAsync(stream, cancellationToken).ConfigureAwait(false);
+                message = await WebRtcSignaling.ReadMessageAsync(stream, cancellationToken).ConfigureAwait(false);
             }
             catch (EndOfStreamException)
             {
@@ -79,7 +79,7 @@ public sealed partial class GrpcEventTransport
                 case SignalMessage.OfferType:
                     session = new WebRtcSession(this, stream);
                     _webRtcSessions.TryAdd(session.Id, session);
-                    await session.HandleOfferAsync(message, cancellationToken).ConfigureAwait(false);
+                    await session.ConnectAsync(message, timeout: null, cancellationToken).ConfigureAwait(false);
                     break;
                 case SignalMessage.CandidateType when session is not null:
                     session.HandleCandidate(message);
@@ -133,7 +133,7 @@ public sealed partial class GrpcEventTransport
         }
     }
 
-    private sealed class WebRtcSession : IAsyncDisposable
+    private sealed class WebRtcSession : IDataChannelSession
     {
         private readonly GrpcEventTransport _transport;
         private readonly NetworkStream _stream;
@@ -178,6 +178,17 @@ public sealed partial class GrpcEventTransport
         }
 
         public Guid Id { get; } = Guid.NewGuid();
+
+        public async Task<bool> ConnectAsync(SignalMessage? offer, TimeSpan? timeout, CancellationToken cancellationToken)
+        {
+            if (offer is null)
+            {
+                return false;
+            }
+
+            await HandleOfferAsync(offer, cancellationToken).ConfigureAwait(false);
+            return true;
+        }
 
         public async Task HandleOfferAsync(SignalMessage offer, CancellationToken cancellationToken)
         {
@@ -270,12 +281,22 @@ public sealed partial class GrpcEventTransport
             return SendMessageAsync(message, cancellationToken);
         }
 
+        Task IDataChannelSession.SendAsync(SignalMessage message, CancellationToken cancellationToken)
+        {
+            return SendAsync(message, cancellationToken);
+        }
+
+        void IDataChannelSession.HookInboundFrames(RTCDataChannel channel)
+        {
+            HookDataChannel(channel);
+        }
+
         private async Task SendMessageAsync(SignalMessage message, CancellationToken cancellationToken)
         {
             await _sendLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                await WriteSignalMessageAsync(_stream, message, cancellationToken).ConfigureAwait(false);
+                await WebRtcSignaling.WriteMessageAsync(_stream, message, cancellationToken).ConfigureAwait(false);
             }
             finally
             {

--- a/src/Yaref92.Events.Transport.Grpc/Platforms/GrpcEventTransport.webrtc.cs
+++ b/src/Yaref92.Events.Transport.Grpc/Platforms/GrpcEventTransport.webrtc.cs
@@ -98,7 +98,7 @@ public sealed partial class GrpcEventTransport
             SignalMessage? message;
             try
             {
-                message = await ReadSignalMessageAsync(stream, cancellationToken).ConfigureAwait(false);
+                message = await WebRtcSignaling.ReadMessageAsync(stream, cancellationToken).ConfigureAwait(false);
             }
             catch (EndOfStreamException)
             {
@@ -115,7 +115,7 @@ public sealed partial class GrpcEventTransport
                 case SignalMessage.OfferType:
                     session = new WebRtcSession(this, stream, ownsStream: false);
                     _webRtcSessions.TryAdd(session.Id, session);
-                    await session.HandleOfferAsync(message, cancellationToken).ConfigureAwait(false);
+                    await session.ConnectAsync(message, timeout: null, cancellationToken).ConfigureAwait(false);
                     break;
                 case SignalMessage.AnswerType when session is not null:
                     await session.HandleAnswerAsync(message, cancellationToken).ConfigureAwait(false);
@@ -149,7 +149,7 @@ public sealed partial class GrpcEventTransport
             _ = Task.Run(() => session.ReceiveSignalingMessagesAsync(cancellationToken), cancellationToken);
 
             var timeout = TimeSpan.FromSeconds(WebRtcAnswerTimeoutSeconds);
-            connected = await session.InitializeOfferAsync(timeout, cancellationToken).ConfigureAwait(false);
+            connected = await session.ConnectAsync(offer: null, timeout, cancellationToken).ConfigureAwait(false);
             if (!connected)
             {
                 return false;
@@ -178,7 +178,7 @@ public sealed partial class GrpcEventTransport
         }
     }
 
-    private sealed class WebRtcSession : IAsyncDisposable
+    private sealed class WebRtcSession : IDataChannelSession
     {
         private readonly GrpcEventTransport _transport;
         private readonly NetworkStream _stream;
@@ -231,6 +231,17 @@ public sealed partial class GrpcEventTransport
 
         public bool IsActive { get; private set; } = true;
 
+        public Task<bool> ConnectAsync(SignalMessage? offer, TimeSpan? timeout, CancellationToken cancellationToken)
+        {
+            if (offer is not null)
+            {
+                return ConnectAsAnswererAsync(offer, cancellationToken);
+            }
+
+            var connectTimeout = timeout ?? TimeSpan.FromSeconds(WebRtcAnswerTimeoutSeconds);
+            return InitializeOfferAsync(connectTimeout, cancellationToken);
+        }
+
         public async Task<bool> InitializeOfferAsync(TimeSpan timeout, CancellationToken cancellationToken)
         {
             _dataChannel = _peerConnection.createDataChannel("events", new RTCDataChannelInit());
@@ -255,7 +266,7 @@ public sealed partial class GrpcEventTransport
                 SignalMessage? message;
                 try
                 {
-                    message = await ReadSignalMessageAsync(_stream, cancellationToken).ConfigureAwait(false);
+                    message = await WebRtcSignaling.ReadMessageAsync(_stream, cancellationToken).ConfigureAwait(false);
                 }
                 catch (EndOfStreamException)
                 {
@@ -394,12 +405,22 @@ public sealed partial class GrpcEventTransport
             return SendMessageAsync(message, cancellationToken);
         }
 
+        Task IDataChannelSession.SendAsync(SignalMessage message, CancellationToken cancellationToken)
+        {
+            return SendAsync(message, cancellationToken);
+        }
+
+        void IDataChannelSession.HookInboundFrames(RTCDataChannel channel)
+        {
+            HookDataChannel(channel);
+        }
+
         private async Task SendMessageAsync(SignalMessage message, CancellationToken cancellationToken)
         {
             await _sendLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                await WriteSignalMessageAsync(_stream, message, cancellationToken).ConfigureAwait(false);
+                await WebRtcSignaling.WriteMessageAsync(_stream, message, cancellationToken).ConfigureAwait(false);
             }
             finally
             {
@@ -422,6 +443,12 @@ public sealed partial class GrpcEventTransport
                 _answerReceived.TrySetResult(false);
                 return false;
             }
+        }
+
+        private async Task<bool> ConnectAsAnswererAsync(SignalMessage offer, CancellationToken cancellationToken)
+        {
+            await HandleOfferAsync(offer, cancellationToken).ConfigureAwait(false);
+            return true;
         }
     }
 }

--- a/src/Yaref92.Events.Transport.Grpc/Platforms/GrpcEventTransport.webrtc.shared.cs
+++ b/src/Yaref92.Events.Transport.Grpc/Platforms/GrpcEventTransport.webrtc.shared.cs
@@ -1,9 +1,4 @@
 #if ANDROID || NOT_ANDROID
-using System.Buffers.Binary;
-using System.Net.Sockets;
-using System.Text.Json;
-using System.Text.Json.Serialization;
-
 using Google.Protobuf;
 using Grpc.Core;
 using SIPSorcery.Net;
@@ -12,34 +7,6 @@ namespace Yaref92.Events.Transport.Grpc;
 
 public sealed partial class GrpcEventTransport
 {
-    private const int SignalMessageBufferSize = 4;
-    private const int MaxSignalMessageSize = 64 * 1024;
-    private static readonly JsonSerializerOptions SignalMessageOptions = new(JsonSerializerDefaults.Web);
-
-    private static async Task<SignalMessage?> ReadSignalMessageAsync(NetworkStream stream, CancellationToken cancellationToken)
-    {
-        byte[] lengthBuffer = new byte[SignalMessageBufferSize];
-        await stream.ReadExactlyAsync(lengthBuffer, cancellationToken).ConfigureAwait(false);
-        int length = BinaryPrimitives.ReadInt32BigEndian(lengthBuffer);
-        if (length <= 0 || length > MaxSignalMessageSize)
-        {
-            return null;
-        }
-
-        byte[] payload = new byte[length];
-        await stream.ReadExactlyAsync(payload, cancellationToken).ConfigureAwait(false);
-        return JsonSerializer.Deserialize<SignalMessage>(payload, SignalMessageOptions);
-    }
-
-    private static async Task WriteSignalMessageAsync(NetworkStream stream, SignalMessage message, CancellationToken cancellationToken)
-    {
-        byte[] payload = JsonSerializer.SerializeToUtf8Bytes(message, SignalMessageOptions);
-        byte[] lengthBuffer = new byte[SignalMessageBufferSize];
-        BinaryPrimitives.WriteInt32BigEndian(lengthBuffer, payload.Length);
-        await stream.WriteAsync(lengthBuffer, cancellationToken).ConfigureAwait(false);
-        await stream.WriteAsync(payload, cancellationToken).ConfigureAwait(false);
-    }
-
     private sealed class WebRtcStreamWriter : IAsyncStreamWriter<TransportFrame>
     {
         private readonly RTCDataChannel _channel;
@@ -80,28 +47,6 @@ public sealed partial class GrpcEventTransport
         {
             return new TransportFrame();
         }
-    }
-
-    private sealed class SignalMessage
-    {
-        public const string OfferType = "offer";
-        public const string AnswerType = "answer";
-        public const string CandidateType = "candidate";
-
-        [JsonPropertyName("type")]
-        public string? Type { get; set; }
-
-        [JsonPropertyName("sdp")]
-        public string? Sdp { get; set; }
-
-        [JsonPropertyName("candidate")]
-        public string? Candidate { get; set; }
-
-        [JsonPropertyName("sdpMid")]
-        public string? SdpMid { get; set; }
-
-        [JsonPropertyName("sdpMLineIndex")]
-        public int? SdpMLineIndex { get; set; }
     }
 }
 #endif

--- a/src/Yaref92.Events.Transport.Grpc/WebRtcSignaling.cs
+++ b/src/Yaref92.Events.Transport.Grpc/WebRtcSignaling.cs
@@ -1,0 +1,59 @@
+using System.Buffers.Binary;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Yaref92.Events.Transport.Grpc;
+
+internal static class WebRtcSignaling
+{
+    private const int SignalMessageBufferSize = 4;
+    private const int MaxSignalMessageSize = 64 * 1024;
+    private static readonly JsonSerializerOptions SignalMessageOptions = new(JsonSerializerDefaults.Web);
+
+    public static async Task<SignalMessage?> ReadMessageAsync(NetworkStream stream, CancellationToken cancellationToken)
+    {
+        byte[] lengthBuffer = new byte[SignalMessageBufferSize];
+        await stream.ReadExactlyAsync(lengthBuffer, cancellationToken).ConfigureAwait(false);
+        int length = BinaryPrimitives.ReadInt32BigEndian(lengthBuffer);
+        if (length <= 0 || length > MaxSignalMessageSize)
+        {
+            return null;
+        }
+
+        byte[] payload = new byte[length];
+        await stream.ReadExactlyAsync(payload, cancellationToken).ConfigureAwait(false);
+        return JsonSerializer.Deserialize<SignalMessage>(payload, SignalMessageOptions);
+    }
+
+    public static async Task WriteMessageAsync(NetworkStream stream, SignalMessage message, CancellationToken cancellationToken)
+    {
+        byte[] payload = JsonSerializer.SerializeToUtf8Bytes(message, SignalMessageOptions);
+        byte[] lengthBuffer = new byte[SignalMessageBufferSize];
+        BinaryPrimitives.WriteInt32BigEndian(lengthBuffer, payload.Length);
+        await stream.WriteAsync(lengthBuffer, cancellationToken).ConfigureAwait(false);
+        await stream.WriteAsync(payload, cancellationToken).ConfigureAwait(false);
+    }
+}
+
+internal sealed class SignalMessage
+{
+    public const string OfferType = "offer";
+    public const string AnswerType = "answer";
+    public const string CandidateType = "candidate";
+
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("sdp")]
+    public string? Sdp { get; set; }
+
+    [JsonPropertyName("candidate")]
+    public string? Candidate { get; set; }
+
+    [JsonPropertyName("sdpMid")]
+    public string? SdpMid { get; set; }
+
+    [JsonPropertyName("sdpMLineIndex")]
+    public int? SdpMLineIndex { get; set; }
+}


### PR DESCRIPTION
### Motivation
- Remove duplicated signaling read/write logic and message model shared between Android and non-Android builds. 
- Provide a single session abstraction so both platform `WebRtcSession` implementations can share lifecycle/connect logic. 
- Reduce complexity in platform-specific files by extracting responsibilities into small helpers and an interface. 

### Description
- Extracted signaling read/write and `SignalMessage` model into `WebRtcSignaling.cs` and replaced previous per-file implementations with `WebRtcSignaling.ReadMessageAsync` and `WebRtcSignaling.WriteMessageAsync` usages. 
- Introduced `IDataChannelSession` interface (`IDataChannelSession.cs`) defining `Id`, `ConnectAsync`, `SendAsync`, `HookInboundFrames`, and `IAsyncDisposable`. 
- Updated Android and non-Android `WebRtcSession` types to implement `IDataChannelSession`, to call `ConnectAsync` for offer/answer flows, and to use the shared signaling helper for message I/O. 
- Kept shared frame envelope conversion and `WebRtcStreamWriter` in the shared `webrtc.shared` file so data-channel serialization remains common. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953f3fd5d148326ad987a3d33dbf246)