### PR TITLE
Unify DataChannel stream registration and log dropped sessions

### DIFF
--- a/src/Yaref92.Events.Transport.Grpc/Platforms/GrpcEventTransport.android.cs
+++ b/src/Yaref92.Events.Transport.Grpc/Platforms/GrpcEventTransport.android.cs
@@ -228,11 +228,8 @@ public sealed partial class GrpcEventTransport
 
         public async ValueTask DisposeAsync()
         {
-            if (_registration is not null)
-            {
-                _transport.UnregisterStream(_registration);
-                _registration = null;
-            }
+            _transport.UnregisterDataChannelSession(_registration, "session disposed");
+            _registration = null;
 
             _dataChannel?.close();
             _peerConnection.close();
@@ -243,8 +240,12 @@ public sealed partial class GrpcEventTransport
         {
             channel.onopen += () =>
             {
-                var writer = new WebRtcStreamWriter(channel);
-                _registration = _transport.RegisterStream(writer);
+                if (_registration is not null)
+                {
+                    _transport.UnregisterDataChannelSession(_registration, "replaced by new data channel open");
+                }
+
+                _registration = _transport.RegisterDataChannelSession(channel);
             };
 
             channel.onmessage += async (_, protocol, data) =>
@@ -266,12 +267,7 @@ public sealed partial class GrpcEventTransport
 
             channel.onclose += () =>
             {
-                if (_registration is null)
-                {
-                    return;
-                }
-
-                _transport.UnregisterStream(_registration);
+                _transport.UnregisterDataChannelSession(_registration, "data channel closed");
                 _registration = null;
             };
         }

--- a/src/Yaref92.Events.Transport.Grpc/Platforms/GrpcEventTransport.webrtc.cs
+++ b/src/Yaref92.Events.Transport.Grpc/Platforms/GrpcEventTransport.webrtc.cs
@@ -347,11 +347,8 @@ public sealed partial class GrpcEventTransport
         public async ValueTask DisposeAsync()
         {
             IsActive = false;
-            if (_registration is not null)
-            {
-                _transport.UnregisterStream(_registration);
-                _registration = null;
-            }
+            _transport.UnregisterDataChannelSession(_registration, "session disposed");
+            _registration = null;
 
             _dataChannel?.close();
             _peerConnection.close();
@@ -368,8 +365,12 @@ public sealed partial class GrpcEventTransport
         {
             channel.onopen += () =>
             {
-                var writer = new WebRtcStreamWriter(channel);
-                _registration = _transport.RegisterStream(writer);
+                if (_registration is not null)
+                {
+                    _transport.UnregisterDataChannelSession(_registration, "replaced by new data channel open");
+                }
+
+                _registration = _transport.RegisterDataChannelSession(channel);
             };
 
             channel.onmessage += async (_, protocol, data) =>
@@ -390,12 +391,7 @@ public sealed partial class GrpcEventTransport
 
             channel.onclose += () =>
             {
-                if (_registration is null)
-                {
-                    return;
-                }
-
-                _transport.UnregisterStream(_registration);
+                _transport.UnregisterDataChannelSession(_registration, "data channel closed");
                 _registration = null;
             };
         }

--- a/src/Yaref92.Events.Transport.Grpc/Platforms/GrpcEventTransport.webrtc.shared.cs
+++ b/src/Yaref92.Events.Transport.Grpc/Platforms/GrpcEventTransport.webrtc.shared.cs
@@ -1,4 +1,6 @@
 #if ANDROID || NOT_ANDROID
+using System.Diagnostics;
+
 using Google.Protobuf;
 using Grpc.Core;
 using SIPSorcery.Net;
@@ -47,6 +49,23 @@ public sealed partial class GrpcEventTransport
         {
             return new TransportFrame();
         }
+    }
+
+    private StreamRegistration RegisterDataChannelSession(RTCDataChannel channel)
+    {
+        var writer = new WebRtcStreamWriter(channel);
+        return RegisterStream(writer);
+    }
+
+    private void UnregisterDataChannelSession(StreamRegistration? registration, string reason)
+    {
+        if (registration is null)
+        {
+            return;
+        }
+
+        UnregisterStream(registration);
+        Trace.TraceInformation("Data channel session {0} closed: {1}", registration.Id, reason);
     }
 }
 #endif


### PR DESCRIPTION
### Motivation
- Introduce a single registration path so DataChannel and gRPC use the same stream registration mechanism.
- Ensure `StreamRegistration` lifecycle is properly tied to DataChannel open/close events across platforms.
- Surface dropped or replaced DataChannel sessions via logging for easier debugging and monitoring.

### Description
- Added `RegisterDataChannelSession(RTCDataChannel)` which creates a `WebRtcStreamWriter` and delegates to the existing `RegisterStream` path.
- Added `UnregisterDataChannelSession(StreamRegistration?, string)` which delegates to `UnregisterStream` and calls `Trace.TraceInformation` to log session closures.
- Replaced inline registrations in WebRTC platform code with `RegisterDataChannelSession` and updated open/close/Dispose handlers to call `UnregisterDataChannelSession` with clear reasons.
- Added `using System.Diagnostics;` and small lifecycle handling to unregister prior sessions when a new data channel opens.

### Testing
- No automated tests were run for this change.
- Build or runtime verification was not executed as part of this PR.
- Manual review focused on ensuring existing `RegisterStream`/`UnregisterStream` behavior is reused and logging is non-blocking.
- Recommend running the transport unit/integration tests and exercising WebRTC data-channel open/close flows to validate behavior after merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953f5a4527c83269399551b271ac784)