### PR TITLE
Prefer WebRTC for Android targets and add outbound WebRTC offer flow

### DIFF
--- a/samples/EventMessenger/MainPage.xaml
+++ b/samples/EventMessenger/MainPage.xaml
@@ -17,6 +17,9 @@
             <Label Text="Peer Host" />
             <Entry Text="{Binding PeerHost}" Placeholder="Hostname or IP" />
 
+            <Label Text="Peer Platform" />
+            <Picker ItemsSource="{Binding PeerPlatforms}" SelectedItem="{Binding SelectedPeerPlatform}" />
+
             <Label Text="Peer Port" />
             <HorizontalStackLayout Spacing="8">
                 <Entry Text="{Binding PeerPort}" Keyboard="Numeric" HorizontalOptions="FillAndExpand" />

--- a/samples/EventMessenger/ViewModels/MainViewModel.cs
+++ b/samples/EventMessenger/ViewModels/MainViewModel.cs
@@ -23,6 +23,7 @@ public class MainViewModel : INotifyPropertyChanged
     private bool _isListening;
     private string _peerHost = "localhost";
     private string _peerPort = "5050";
+    private string _selectedPeerPlatform = "Windows";
     private string _myPort = "5050";
     private string _messageText = string.Empty;
 
@@ -54,6 +55,14 @@ public class MainViewModel : INotifyPropertyChanged
     {
         get => _peerPort;
         set => SetProperty(ref _peerPort, value);
+    }
+
+    public IReadOnlyList<string> PeerPlatforms { get; } = new[] { "Android", "Windows" };
+
+    public string SelectedPeerPlatform
+    {
+        get => _selectedPeerPlatform;
+        set => SetProperty(ref _selectedPeerPlatform, value);
     }
 
     public string MyPort
@@ -93,6 +102,7 @@ public class MainViewModel : INotifyPropertyChanged
             return;
         }
 
+        _transport.TargetPlatform = SelectedPeerPlatform;
         await _transport.ConnectToPeerAsync(PeerHost, port);
         await ShowToastAsync($"Connected to {PeerHost}:{PeerPort}");
     }

--- a/src/Yaref92.Events.Transport.Grpc/GrpcEventTransport.cs
+++ b/src/Yaref92.Events.Transport.Grpc/GrpcEventTransport.cs
@@ -12,12 +12,22 @@ namespace Yaref92.Events.Transport.Grpc;
 
 public sealed partial class GrpcEventTransport : IEventTransport, IAsyncDisposable
 {
+    private const string PlatformAndroid = "android";
+    private const string PlatformWindows = "windows";
+
+    internal enum TransportMode
+    {
+        Grpc,
+        WebRtcDataChannel,
+    }
+
     private readonly int _listenPort;
     private readonly IEventSerializer _serializer;
     private readonly ConcurrentDictionary<Guid, StreamRegistration> _activeStreams = new();
     private readonly ConcurrentBag<GrpcChannel> _channels = new();
     private Task? _disposeTask;
     private int _disposeState;
+    private string? _targetPlatform;
 
     internal ISessionManager SessionManager { get; }
 
@@ -31,12 +41,23 @@ public sealed partial class GrpcEventTransport : IEventTransport, IAsyncDisposab
 
     public event IEventTransport.SessionInboundConnectionDroppedHandler? SessionInboundConnectionDropped;
 
+    public string? TargetPlatform
+    {
+        get => _targetPlatform;
+        set
+        {
+            _targetPlatform = value;
+            SessionManager.Options.TargetPlatform = value;
+        }
+    }
+
     public GrpcEventTransport(int listenPort, ISessionManager sessionManager, IEventSerializer? serializer = null)
     {
         _listenPort = listenPort;
         SessionManager = sessionManager;
         _serializer = serializer ?? new JsonEventSerializer();
         AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+        EnsureLocalPlatform();
     }
 #if !ANDROID && !NOT_ANDROID
     public Task StartListeningAsync(CancellationToken cancellationToken = default)
@@ -66,12 +87,75 @@ public sealed partial class GrpcEventTransport : IEventTransport, IAsyncDisposab
             SessionManager.HydrateAnonymousSessionId(sessionKey, new DnsEndPoint(host, port));
         }
 
-#if NOT_ANDROID
-        if (await TryConnectToPeerViaWebRtcAsync(host, port, cancellationToken).ConfigureAwait(false))
+        var transportMode = ResolveTransportMode(sessionKey);
+
+        if (transportMode == TransportMode.WebRtcDataChannel
+            && await TryConnectToPeerViaWebRtcAsync(host, port, cancellationToken).ConfigureAwait(false))
         {
             return;
         }
+
+        await ConnectToPeerViaGrpcAsync(host, port, cancellationToken).ConfigureAwait(false);
+    }
+
+    private TransportMode ResolveTransportMode(SessionKey sessionKey)
+    {
+        if (RequiresServerBasedConnection(sessionKey))
+        {
+            return TransportMode.Grpc;
+        }
+
+        return ShouldUseWebRtcForTarget() ? TransportMode.WebRtcDataChannel : TransportMode.Grpc;
+    }
+
+    private bool RequiresServerBasedConnection(SessionKey sessionKey)
+    {
+        var options = SessionManager.Options;
+        if (!options.RequireAuthentication)
+        {
+            return false;
+        }
+
+        if (!sessionKey.IsAnonymousKey)
+        {
+            return true;
+        }
+
+        return options.DoAnonymousSessionsRequireAuthentication;
+    }
+
+    private bool ShouldUseWebRtcForTarget()
+    {
+        var targetPlatform = _targetPlatform ?? SessionManager.Options.TargetPlatform;
+        return IsPlatform(targetPlatform, PlatformAndroid);
+    }
+
+    private void EnsureLocalPlatform()
+    {
+        if (!string.IsNullOrWhiteSpace(SessionManager.Options.LocalPlatform))
+        {
+            return;
+        }
+
+        SessionManager.Options.LocalPlatform = ResolveLocalPlatform();
+    }
+
+    private static string? ResolveLocalPlatform()
+    {
+#if ANDROID
+        return PlatformAndroid;
+#else
+        return OperatingSystem.IsWindows() ? PlatformWindows : null;
 #endif
+    }
+
+    private static bool IsPlatform(string? platform, string expected)
+    {
+        return string.Equals(platform, expected, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private Task ConnectToPeerViaGrpcAsync(string host, int port, CancellationToken cancellationToken)
+    {
         var channel = GrpcChannel.ForAddress($"http://{host}:{port}");
         _channels.Add(channel);
 
@@ -80,6 +164,8 @@ public sealed partial class GrpcEventTransport : IEventTransport, IAsyncDisposab
         var registration = RegisterStream(call.RequestStream);
         _ = ProcessIncomingStreamAsync(call.ResponseStream, registration, cancellationToken)
             .ContinueWith(_ => UnregisterStream(registration), TaskScheduler.Default);
+
+        return Task.CompletedTask;
     }
 
     public async Task PublishEventAsync<T>(T domainEvent, CancellationToken cancellationToken = default) where T : class, IDomainEvent

--- a/src/Yaref92.Events.Transport.Grpc/Platforms/GrpcEventTransport.android.cs
+++ b/src/Yaref92.Events.Transport.Grpc/Platforms/GrpcEventTransport.android.cs
@@ -9,6 +9,7 @@ namespace Yaref92.Events.Transport.Grpc;
 
 public sealed partial class GrpcEventTransport
 {
+    private const int WebRtcAnswerTimeoutSeconds = 5;
     private readonly ConcurrentDictionary<Guid, WebRtcSession> _webRtcSessions = new();
     private TcpListener? _signalingListener;
     private CancellationTokenSource? _signalingCts;
@@ -77,7 +78,7 @@ public sealed partial class GrpcEventTransport
             switch (message.Type)
             {
                 case SignalMessage.OfferType:
-                    session = new WebRtcSession(this, stream);
+                    session = new WebRtcSession(this, stream, ownsStream: false);
                     _webRtcSessions.TryAdd(session.Id, session);
                     await session.ConnectAsync(message, timeout: null, cancellationToken).ConfigureAwait(false);
                     break;
@@ -133,19 +134,70 @@ public sealed partial class GrpcEventTransport
         }
     }
 
+    private async Task<bool> TryConnectToPeerViaWebRtcAsync(string host, int port, CancellationToken cancellationToken)
+    {
+        TcpClient? client = null;
+        WebRtcSession? session = null;
+        var connected = false;
+
+        try
+        {
+            client = new TcpClient();
+            await client.ConnectAsync(host, port, cancellationToken).ConfigureAwait(false);
+            NetworkStream stream = client.GetStream();
+            session = new WebRtcSession(this, stream, ownsStream: true, client);
+            _webRtcSessions.TryAdd(session.Id, session);
+            _ = Task.Run(() => session.ReceiveSignalingMessagesAsync(cancellationToken), cancellationToken);
+
+            var timeout = TimeSpan.FromSeconds(WebRtcAnswerTimeoutSeconds);
+            connected = await session.ConnectAsync(offer: null, timeout, cancellationToken).ConfigureAwait(false);
+            if (!connected)
+            {
+                return false;
+            }
+
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+        finally
+        {
+            if (session is null)
+            {
+                client?.Dispose();
+            }
+            else if (!connected || !session.IsActive)
+            {
+                _webRtcSessions.TryRemove(session.Id, out var _);
+                await session.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+    }
+
     private sealed class WebRtcSession : IDataChannelSession
     {
         private readonly GrpcEventTransport _transport;
         private readonly NetworkStream _stream;
         private readonly RTCPeerConnection _peerConnection;
         private readonly SemaphoreSlim _sendLock = new(1, 1);
+        private readonly bool _ownsStream;
+        private readonly TcpClient? _client;
+        private readonly TaskCompletionSource<bool> _answerReceived = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private RTCDataChannel? _dataChannel;
         private StreamRegistration? _registration;
 
-        public WebRtcSession(GrpcEventTransport transport, NetworkStream stream)
+        public WebRtcSession(GrpcEventTransport transport, NetworkStream stream, bool ownsStream, TcpClient? client = null)
         {
             _transport = transport;
             _stream = stream;
+            _ownsStream = ownsStream;
+            _client = client;
             _peerConnection = new RTCPeerConnection(new RTCConfiguration
             {
                 iceServers = new List<RTCIceServer>
@@ -179,15 +231,65 @@ public sealed partial class GrpcEventTransport
 
         public Guid Id { get; } = Guid.NewGuid();
 
-        public async Task<bool> ConnectAsync(SignalMessage? offer, TimeSpan? timeout, CancellationToken cancellationToken)
+        public bool IsActive { get; private set; } = true;
+
+        public Task<bool> ConnectAsync(SignalMessage? offer, TimeSpan? timeout, CancellationToken cancellationToken)
         {
             if (offer is null)
             {
-                return false;
+                var connectTimeout = timeout ?? TimeSpan.FromSeconds(WebRtcAnswerTimeoutSeconds);
+                return InitializeOfferAsync(connectTimeout, cancellationToken);
             }
 
-            await HandleOfferAsync(offer, cancellationToken).ConfigureAwait(false);
-            return true;
+            return ConnectAsAnswererAsync(offer, cancellationToken);
+        }
+
+        public async Task<bool> InitializeOfferAsync(TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            _dataChannel = _peerConnection.createDataChannel("events", new RTCDataChannelInit());
+            HookDataChannel(_dataChannel);
+
+            var offer = _peerConnection.createOffer(null);
+            await _peerConnection.setLocalDescription(offer).ConfigureAwait(false);
+
+            await SendAsync(new SignalMessage
+            {
+                Type = SignalMessage.OfferType,
+                Sdp = offer.sdp,
+            }, cancellationToken).ConfigureAwait(false);
+
+            return await WaitForAnswerAsync(timeout, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task ReceiveSignalingMessagesAsync(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                SignalMessage? message;
+                try
+                {
+                    message = await WebRtcSignaling.ReadMessageAsync(_stream, cancellationToken).ConfigureAwait(false);
+                }
+                catch (EndOfStreamException)
+                {
+                    break;
+                }
+
+                if (message is null)
+                {
+                    break;
+                }
+
+                switch (message.Type)
+                {
+                    case SignalMessage.AnswerType:
+                        await HandleAnswerAsync(message, cancellationToken).ConfigureAwait(false);
+                        break;
+                    case SignalMessage.CandidateType:
+                        HandleCandidate(message);
+                        break;
+                }
+            }
         }
 
         public async Task HandleOfferAsync(SignalMessage offer, CancellationToken cancellationToken)
@@ -209,6 +311,24 @@ public sealed partial class GrpcEventTransport
             }, cancellationToken).ConfigureAwait(false);
         }
 
+        public async Task HandleAnswerAsync(SignalMessage answer, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(answer.Sdp))
+            {
+                return;
+            }
+
+            var answerDescription = new RTCSessionDescriptionInit
+            {
+                type = RTCSdpType.answer,
+                sdp = answer.Sdp,
+            };
+
+            _peerConnection.setRemoteDescription(answerDescription);
+            _answerReceived.TrySetResult(true);
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+
         public void HandleCandidate(SignalMessage candidate)
         {
             if (string.IsNullOrWhiteSpace(candidate.Candidate))
@@ -228,12 +348,19 @@ public sealed partial class GrpcEventTransport
 
         public async ValueTask DisposeAsync()
         {
+            IsActive = false;
             _transport.UnregisterDataChannelSession(_registration, "session disposed");
             _registration = null;
 
             _dataChannel?.close();
             _peerConnection.close();
             _sendLock.Dispose();
+
+            if (_ownsStream)
+            {
+                await _stream.DisposeAsync().ConfigureAwait(false);
+                _client?.Dispose();
+            }
         }
 
         private void HookDataChannel(RTCDataChannel channel)
@@ -298,6 +425,29 @@ public sealed partial class GrpcEventTransport
             {
                 _sendLock.Release();
             }
+        }
+
+        private async Task<bool> WaitForAnswerAsync(TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(timeout);
+
+            try
+            {
+                await _answerReceived.Task.WaitAsync(timeoutCts.Token).ConfigureAwait(false);
+                return true;
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                _answerReceived.TrySetResult(false);
+                return false;
+            }
+        }
+
+        private async Task<bool> ConnectAsAnswererAsync(SignalMessage offer, CancellationToken cancellationToken)
+        {
+            await HandleOfferAsync(offer, cancellationToken).ConfigureAwait(false);
+            return true;
         }
     }
 

--- a/src/Yaref92.Events/Sessions/ResilientSessionOptions.cs
+++ b/src/Yaref92.Events/Sessions/ResilientSessionOptions.cs
@@ -37,6 +37,16 @@ public sealed class ResilientSessionOptions
     public int CallbackPort { get; set; }
 
     /// <summary>
+    /// Local platform name advertised to peers during authentication.
+    /// </summary>
+    public string? LocalPlatform { get; set; }
+
+    /// <summary>
+    /// Target platform selection advertised to peers during authentication.
+    /// </summary>
+    public string? TargetPlatform { get; set; }
+
+    /// <summary>
     /// Checks that all options are valid, returning false if not.
     /// </summary>
     public bool Validate()

--- a/src/Yaref92.Events/Sessions/SessionFrameContract.cs
+++ b/src/Yaref92.Events/Sessions/SessionFrameContract.cs
@@ -39,7 +39,9 @@ public static class SessionFrameContract
         var payload = new SessionAuthenticationPayload(
             options.RequireAuthentication ? ResolveSecret(authenticationSecret, options) : null,
             options.CallbackHost,
-            options.CallbackPort > 0 ? options.CallbackPort : null);
+            options.CallbackPort > 0 ? options.CallbackPort : null,
+            options.LocalPlatform,
+            options.TargetPlatform);
 
         var payloadJson = JsonSerializer.Serialize(payload, AuthPayloadSerializerOptions);
         return SessionFrame.CreateAuth(sessionToken, payloadJson);
@@ -230,9 +232,14 @@ public static class SessionFrameContract
         }
         catch (JsonException)
         {
-            return new SessionAuthenticationPayload(payload, null, null);
+            return new SessionAuthenticationPayload(payload, null, null, null, null);
         }
     }
 }
 
-public sealed record SessionAuthenticationPayload(string? Secret, string? CallbackHost, int? CallbackPort);
+public sealed record SessionAuthenticationPayload(
+    string? Secret,
+    string? CallbackHost,
+    int? CallbackPort,
+    string? LocalPlatform,
+    string? TargetPlatform);


### PR DESCRIPTION
### Motivation
- Prefer peer-to-peer WebRTC when the selected remote platform is Android so Android-targeted connections attempt data-channel transport. 
- Surface local and chosen target platform metadata during session authentication so peers can make transport decisions. 
- Replace the compile-time platform guard with a runtime transport selection to honor session options and authentication requirements. 
- Support initiating (offer) WebRTC flows from non-Android peers dialing Android endpoints and correctly manage stream ownership.

### Description
- Removed the `#if` platform guard and introduced `ResolveTransportMode`, `RequiresServerBasedConnection`, and `ShouldUseWebRtcForTarget` to pick `TransportMode` at runtime and attempt WebRTC only when appropriate. 
- Added `TargetPlatform` property to `GrpcEventTransport` and `LocalPlatform`/`TargetPlatform` to `ResilientSessionOptions`, and included both fields in the serialized `SessionAuthenticationPayload` via `SessionFrameContract`. 
- Implemented an outbound WebRTC offer flow on Android (`TryConnectToPeerViaWebRtcAsync`) and extended `WebRtcSession` with ownership handling, `InitializeOfferAsync`, `ReceiveSignalingMessagesAsync`, `HandleAnswerAsync`, `WaitForAnswerAsync`, and `IsActive`/dispose semantics to ensure resources are cleaned up correctly. 
- Added platform helpers (`EnsureLocalPlatform`, `ResolveLocalPlatform`, `IsPlatform`) and a small timeout constant (`WebRtcAnswerTimeoutSeconds`) to control answer waits.

### Testing
- No automated tests were run against these changes. 
- CI was not executed for this update. 
- Manual/interactive verification was not performed as part of this rollout. 
- Recommended automated tests (not executed) include `ResolveTransportMode` permutations and `SessionAuthenticationPayload` parse/round-trip serialization.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953f718230c8326acef699ddeee0d17)