### PR TITLE
Initiate reverse dial on gRPC auth using session metadata

### DIFF
--- a/src/Yaref92.Events.Transport.Grpc/GrpcEventTransport.cs
+++ b/src/Yaref92.Events.Transport.Grpc/GrpcEventTransport.cs
@@ -324,7 +324,14 @@ public sealed partial class GrpcEventTransport : IEventTransport, IAsyncDisposab
         {
             var session = SessionManager.ResolveSession(null, authFrame);
             registration.IsAuthenticated = true;
-            await InitiateReverseConnectionAsync(session, authFrame).ConfigureAwait(false);
+            try
+            {
+                await InitiateReverseConnectionAsync(session, authFrame).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Reverse dial is best-effort; keep inbound stream alive even if it fails.
+            }
             return true;
         }
         catch (System.Security.Authentication.AuthenticationException)

--- a/src/Yaref92.Events.Transport.Grpc/GrpcEventTransport.cs
+++ b/src/Yaref92.Events.Transport.Grpc/GrpcEventTransport.cs
@@ -142,10 +142,20 @@ public sealed partial class GrpcEventTransport : IEventTransport, IAsyncDisposab
         return options.DoAnonymousSessionsRequireAuthentication;
     }
 
-    private bool ShouldUseWebRtcForTarget()
+    private bool ShouldUseWebRtcForTarget(Platform? targetPlatform = null)
     {
-        var targetPlatform = _targetPlatform ?? SessionManager.Options.TargetPlatform;
-        return targetPlatform == Platform.Android;
+        var resolvedTarget = targetPlatform ?? _targetPlatform ?? SessionManager.Options.TargetPlatform;
+        return resolvedTarget == Platform.Android;
+    }
+
+    private TransportMode ResolveTransportMode(SessionKey sessionKey, Platform? targetPlatform)
+    {
+        if (RequiresServerBasedConnection(sessionKey))
+        {
+            return TransportMode.Grpc;
+        }
+
+        return ShouldUseWebRtcForTarget(targetPlatform) ? TransportMode.WebRtcDataChannel : TransportMode.Grpc;
     }
 
     private TransportFrame CreateAuthFrame(SessionKey sessionKey)
@@ -251,7 +261,7 @@ public sealed partial class GrpcEventTransport : IEventTransport, IAsyncDisposab
     {
         if (frame.Kind == FrameKind.Auth)
         {
-            return HandleAuthFrame(frame, registration);
+            return await HandleAuthFrameAsync(frame, registration).ConfigureAwait(false);
         }
 
         if (frame.Kind != FrameKind.Event)
@@ -307,13 +317,14 @@ public sealed partial class GrpcEventTransport : IEventTransport, IAsyncDisposab
         return WriteFrameAsync(registration, CreateAuthFrame(sessionKey));
     }
 
-    private bool HandleAuthFrame(TransportFrame frame, StreamRegistration registration)
+    private async Task<bool> HandleAuthFrameAsync(TransportFrame frame, StreamRegistration registration)
     {
         var authFrame = SessionFrame.CreateAuth(frame.EventId ?? string.Empty, frame.EventJson);
         try
         {
-            SessionManager.ResolveSession(null, authFrame);
+            var session = SessionManager.ResolveSession(null, authFrame);
             registration.IsAuthenticated = true;
+            await InitiateReverseConnectionAsync(session, authFrame).ConfigureAwait(false);
             return true;
         }
         catch (System.Security.Authentication.AuthenticationException)
@@ -321,6 +332,31 @@ public sealed partial class GrpcEventTransport : IEventTransport, IAsyncDisposab
             registration.IsAuthenticated = false;
             return false;
         }
+    }
+
+    private async Task InitiateReverseConnectionAsync(IResilientPeerSession session, SessionFrame authFrame)
+    {
+        if (!SessionFrameContract.TryValidateAuthentication(authFrame, SessionManager.Options, out _, out var payload))
+        {
+            return;
+        }
+
+        var sessionKey = session.Key;
+        var callbackHost = string.IsNullOrWhiteSpace(payload?.CallbackHost) ? sessionKey.Host : payload.CallbackHost;
+        var callbackPort = payload?.CallbackPort ?? sessionKey.Port;
+        if (string.IsNullOrWhiteSpace(callbackHost) || callbackPort <= 0)
+        {
+            return;
+        }
+
+        var transportMode = ResolveTransportMode(sessionKey, payload?.LocalPlatform ?? payload?.TargetPlatform);
+        if (transportMode == TransportMode.WebRtcDataChannel
+            && await TryConnectToPeerViaWebRtcAsync(sessionKey, callbackHost, callbackPort, CancellationToken.None).ConfigureAwait(false))
+        {
+            return;
+        }
+
+        await ConnectToPeerViaGrpcAsync(sessionKey, callbackHost, callbackPort, CancellationToken.None).ConfigureAwait(false);
     }
 
     private static TransportFrame CreateEventFrame<T>(T domainEvent, string eventEnvelopeJson) where T : class, IDomainEvent


### PR DESCRIPTION
### Motivation
- Mirror TCP behavior by initiating a reverse connection back to the peer when an inbound gRPC auth succeeds.
- Use the session's advertised callback host/port and platform metadata to determine how to dial the peer.
- Prefer WebRTC for Android-targeted peers and fall back to gRPC when appropriate.

### Description
- Changed `HandleIncomingFrameAsync` to await a new async `HandleAuthFrameAsync` path for auth frames.
- Replaced the synchronous `HandleAuthFrame` with `HandleAuthFrameAsync` which resolves the session via `SessionManager.ResolveSession` and then calls a new `InitiateReverseConnectionAsync` routine.
- Added `InitiateReverseConnectionAsync` which uses `SessionFrameContract.TryValidateAuthentication` to extract callback host/port and platform, then selects a transport via the new `ResolveTransportMode`/`ShouldUseWebRtcForTarget` signatures and attempts `TryConnectToPeerViaWebRtcAsync` before falling back to `ConnectToPeerViaGrpcAsync`.
- Adjusted `ShouldUseWebRtcForTarget` to accept an optional `Platform` hint and added `ResolveTransportMode(SessionKey, Platform?)` to allow platform-aware transport selection when initiating reverse dials.

### Testing
- No automated tests were executed as part of this change.
- Manual or CI validation was not requested in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69610d3e3ecc8326862d22f274c1d67d)