### PR TITLE
Match RegisterStream signature in WebRTC data channel registration

### DIFF
--- a/src/Yaref92.Events.Transport.Grpc/Platforms/GrpcEventTransport.webrtc.shared.cs
+++ b/src/Yaref92.Events.Transport.Grpc/Platforms/GrpcEventTransport.webrtc.shared.cs
@@ -54,7 +54,7 @@ public sealed partial class GrpcEventTransport
     private StreamRegistration RegisterDataChannelSession(RTCDataChannel channel)
     {
         var writer = new WebRtcStreamWriter(channel);
-        return RegisterStream(writer);
+        return RegisterStream(writer, null);
     }
 
     private void UnregisterDataChannelSession(StreamRegistration? registration, string reason)


### PR DESCRIPTION
### Motivation
- Align the WebRTC data channel registration call with the updated `RegisterStream` signature by supplying an `EndPoint` argument (using `null` when none is available).

### Description
- Update `RegisterDataChannelSession` to call `RegisterStream(writer, null)` instead of `RegisterStream(writer)` in `src/Yaref92.Events.Transport.Grpc/Platforms/GrpcEventTransport.webrtc.shared.cs`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968a9f271148326ac2ad1d65ff27a4a)